### PR TITLE
ADT 3.3.5 support

### DIFF
--- a/adt_file.py
+++ b/adt_file.py
@@ -101,9 +101,10 @@ class ADTFile:
 			self._size_changed(-MTXF.entry_size, self.mtxf.address)
 
 	def _add_model_filename(self, filename, filename_chunk, offset_chunk):
-		for i, j in enumerate(filename_chunk.filenames):
-			if j == filename:
-				return i
+		try:
+			return filename_chunk.filenames.index(filename)
+		except:
+			pass
 
 		ofs_in_fc = filename_chunk.filenames.size
 		# Dirty, but should be safe:

--- a/adt_file.py
+++ b/adt_file.py
@@ -8,11 +8,14 @@ __reload_order_index__ = 3
 
 class ADTFile:
 	# def __init__(self, version, filepath=None):
-	def __init__(self, filepath=None):
+	def __init__(self, filepath=None, highres=True):
 
 		self.filepath = filepath
 		self._mobile_chunks = []
 		self._offsets = []
+
+		# TODO: read from WDT MPHD flags if available?
+		self.highres = highres
 
 		# initialize chunks
 		self.mver = MVER()
@@ -57,27 +60,12 @@ class ADTFile:
 	def _get_mwmo_data_start(self):
 		return self.mwmo.address + ChunkHeader.size
 
-	
-	def guess_alpha_is_highres(self):
-		for row in range(16):
-			for col in range(16):
-				chunk = self.mcnk[row][col]
-				for layer in chunk.mcly.layers:
-					if layer.flags & ADTChunkLayerFlags.alpha_map_compressed:
-						return True
-				for layer in chunk.mcal.layers:
-					if layer.type in [ADTAlphaTypes.HIGHRES, ADTAlphaTypes.HIGHRES_COMPRESSED]:
-						return True
-					else:
-						return False
-		return False
-
-
 	def add_texture_filename(self, filename, mtxf_flags=0):
-		for i, j in enumerate(self.mtex.filenames):
-			if j == filename:
-				return i
-
+		try:
+			return self.mtex.filenames.index(filename)
+		except:	# Python, more like Fuckoff
+			pass
+		
 		self.mtex.filenames._add(filename)
 		size = len(filename) + 1
 		self._size_changed(size, self.mtex.address)

--- a/adt_file.py
+++ b/adt_file.py
@@ -1,68 +1,389 @@
 from .file_formats.adt_chunks import *
 from .file_formats.wow_common_types import ChunkHeader
+from .enums.adt_enums import *
 from io import BufferedReader
 
 __reload_order_index__ = 3
 
 
 class ADTFile:
-    def __init__(self, file=None):
+	# def __init__(self, version, filepath=None):
+	def __init__(self, filepath=None):
 
-        self.header = MHDR()
-        self.textures = MTEX()
-        self.model_filenames = []
-        self.map_object_filenames = []
-        self.model_instances = MDDF()
-        self.map_object_instances = MODF()
-        self.chunks = [[MCNK() for _ in range(16)] for _ in range(16)]
+		self.filepath = filepath
+		self._mobile_chunks = []
+		self._offsets = []
 
-        if file:
-            if type(file) is BufferedReader:
-                self.read(file)
+		# initialize chunks
+		self.mver = MVER()
+		self.mhdr = MHDR(self)
+		self.mcin = MCIN(self)
+		self.mtex = MTEX(self)
+		self.mmdx = MMDX(self)
+		self.mmid = MMID(self)
+		self.mwmo = MWMO(self)
+		self.mwid = MWID(self)
+		self.mddf = MDDF(self)
+		self.modf = MODF(self)
+		self.mfbo = MFBO(self)
+		self.mh2o = MH2O(self)
+		self.mtxf = MTXF(self)
+		self.mcnk = [[MCNK(self) for _ in range(16)] for _ in range(16)]
 
-            elif type(file) is str:
-                with open(file, 'rb') as f:
-                    self.read(f)
+		if self.filepath:
+			with open(self.filepath, 'rb') as f:
+				self.read(f)
 
-            else:
-                raise NotImplementedError('\nFile argument must be either a filepath string or io.BufferedReader')
+	def _register_mobile_chunk(self, chunk):
+		self._mobile_chunks.append(chunk)
 
-    def read(self, f):
+	def _update_mobile_chunks(self, distance, address_of_changed):
+		for chunk in self._mobile_chunks:
+			chunk.update_address(distance, address_of_changed)
 
-        mver = MVER().read(f)
+	def _register_offset(self, ofs):
+		self._offsets.append(ofs)
 
-        if mver.version != 18:  # Blizzard has never cared to change it so far
-            raise NotImplementedError('Unknown ADT version: ({})'.format(mver.version))
+	def _unregister_offset(self, ofs):
+		self._offsets.remove(ofs)
 
-        mhdr = MHDR().read(f)
+	def _update_offsets(self, distance, address_of_changed):
+		for ofs in self._offsets:
+			ofs._update(distance, address_of_changed)
 
-        # read header chunks
+	def _get_mmdx_data_start(self):
+		return self.mmdx.address + ChunkHeader.size
 
-        f.seek(mhdr.mcin)
-        mcnk_pointers = MCIN().read(f)
+	def _get_mwmo_data_start(self):
+		return self.mwmo.address + ChunkHeader.size
 
-        f.seek(mhdr.mtex)
-        self.textures.read(f)
-
-        f.seek(mhdr.mmid)
-        mmid = MMID().read(f)
-
-        f.seek(mhdr.mmdx)
-        mmdx_header = ChunkHeader().read(f)
-        mmdx_data_pos = f.tell()
-
-        assert mmdx_header == 'XDMM'
-
-
-
-
-
-
-
-
-
-
-
+	
+	def guess_alpha_is_highres(self):
+		for row in range(16):
+			for col in range(16):
+				chunk = self.mcnk[row][col]
+				for layer in chunk.mcly.layers:
+					if layer.flags & ADTChunkLayerFlags.alpha_map_compressed:
+						return True
+				for layer in chunk.mcal.layers:
+					if layer.type in [ADTAlphaTypes.HIGHRES, ADTAlphaTypes.HIGHRES_COMPRESSED]:
+						return True
+					else:
+						return False
+		return False
 
 
+	def add_texture_filename(self, filename, mtxf_flags=0):
+		for i, j in enumerate(self.mtex.filenames):
+			if j == filename:
+				return i
 
+		self.mtex.filenames._add(filename)
+		size = len(filename) + 1
+		self._size_changed(size, self.mtex.address)
+
+		if int(self.mhdr.ofs_mtxf):
+			self.mtxf._add(mtxf_flags)
+			self._size_changed(MTXF.entry_size, self.mtxf.address)
+		
+		return len(self.mtex.filenames) - 1
+
+	def replace_texture_filename(self, index, new_filename):
+		if index > len(self.mtex.filenames) - 1:
+			raise IndexError("Index not in filenames: {}".format(index))
+		
+		old_size = len(self.mtex.filenames[index])
+		new_size = len(new_filename)
+		self.mtex.filenames._replace(index, new_filename)
+		size_change = new_size - old_size
+		if size_change:
+			self._size_changed(size_change, self.mtex.address)
+
+	def remove_texture_filename(self, index):
+		# TODO: what do we do with MCLY entries that ref this?
+		if index > len(self.mtex.filenames) - 1:
+			raise IndexError("Index not in filenames: {}".format(index))
+		
+		size_change = -(len(self.mtex.filenames[index]) + 1)
+		self.mtex.filenames._remove(index)
+		self._size_changed(size_change, self.mtex.address)
+
+		if int(self.mhdr.ofs_mtxf):
+			self.mtxf._remove(index)
+			self._size_changed(-MTXF.entry_size, self.mtxf.address)
+
+	def _add_model_filename(self, filename, filename_chunk, offset_chunk):
+		for i, j in enumerate(filename_chunk.filenames):
+			if j == filename:
+				return i
+
+		ofs_in_fc = filename_chunk.filenames.size
+		# Dirty, but should be safe:
+		address_of_changed = filename_chunk.address + filename_chunk.filenames.size + ChunkHeader.size - 1
+		filename_chunk.filenames._add(filename)
+		distance = len(filename) + 1
+		self._size_changed(distance, address_of_changed)
+		offset_chunk._add(ofs_in_fc)
+		self._size_changed(offset_chunk.entry_size, offset_chunk.address)
+
+		return len(filename_chunk.filenames) - 1
+
+	def _replace_model_filename(self, index, new_filename, filename_chunk, offset_chunk):
+		if index > len(filename_chunk.filenames) - 1:
+			raise IndexError("Index not in filenames: {}".format(index))
+		
+		address_of_changed = offset_chunk.offsets[index].absolute
+		old_size = len(filename_chunk.filenames[index])
+		new_size = len(new_filename)
+		filename_chunk.filenames._replace(index, new_filename)
+		distance = new_size - old_size
+		if distance:
+			self._size_changed(distance, address_of_changed)
+
+	def _remove_model_filename(self, index, filename_chunk, offset_chunk):
+		if index > len(filename_chunk.filenames) - 1:
+			raise IndexError("Index not in filenames: {}".format(index))
+		
+		address_of_changed = offset_chunk.offsets[index].absolute
+		distance = -(len(filename_chunk.filenames[index]) + 1)
+		filename_chunk.filenames._remove(index)
+		self._size_changed(distance, address_of_changed)
+
+		offset_chunk._remove(index)
+		address_of_changed = offset_chunk.address
+		distance = -offset_chunk.entry_size
+		self._size_changed(distance, address_of_changed)
+	
+	def add_m2_filename(self, filename):
+		return self._add_model_filename(filename, self.mmdx, self.mmid)
+	def replace_m2_filename(self, index, new_filename):
+		self._replace_model_filename(index, new_filename, self.mmdx, self.mmid)
+	def remove_m2_filename(self, index):
+		self._remove_model_filename(index, self.mmdx, self.mmid)
+
+	def add_wmo_filename(self, filename):
+		self._add_model_filename(filename, self.mwmo, self.mwid)
+	def replace_wmo_filename(self, index, new_filename):
+		self._replace_model_filename(index, new_filename, self.mwmo, self.mwid)
+	def remove_wmo_filename(self, index):
+		self._remove_model_filename(index, self.mwmo, self.mwid)
+
+
+	def add_m2_instance(self, which_chunks, name_id, unique_id, position, rotation, scale, flags):
+		self.mddf._add(name_id, unique_id, position, rotation, scale, flags)
+		distance = ADTDoodadDefinition.size
+		self._size_changed(distance, self.mddf.address)
+
+		for row, col in which_chunks:	# list of tuples [(row, col), (row, col), etc]
+			mddf_index = len(self.mddf.doodad_instances) - 1
+			self.mcnk[row][col].mcrf._add_doodad(mddf_index)
+			self._size_changed(MCRF.entry_size, self.mcnk[row][col].mcrf.address)
+			self.mcnk[row][col].n_doodad_refs += 1
+		# TODO: sort MCRF doodad_refs by size category		
+
+	def remove_m2_instance(self, index):
+		if index > len(self.mddf.doodad_instances) - 1:
+			raise IndexError("Index not in doodad_instances: {}".format(index))
+
+		self.mddf._remove(index)
+		distance = -ADTDoodadDefinition.size
+		self._size_changed(distance, self.mddf.address)
+
+		for row in range(16):
+			for col in range(16):
+				chunk = self.mcnk[row][col]
+				if index in chunk.mcrf.doodad_refs:
+					chunk.mcrf._remove_doodad(index)
+					self._size_changed(-MCRF.entry_size, chunk.mcrf.address)
+					chunk.n_doodad_refs -= 1
+
+	
+	def add_wmo_instance(self, which_chunks, name_id, unique_id, position, rotation, 
+						extents, flags, doodad_set, name_set, scale):
+		self.modf._add(name_id, unique_id, position, rotation, 
+						extents, flags, doodad_set, name_set, scale)
+		distance = ADTWMODefinition.size
+		self._size_changed(distance, self.modf.address)
+
+		for row, col in which_chunks:	# list of tuples [(row, col), (row, col), etc]
+			modf_index = len(self.modf.wmo_instances) - 1
+			self.mcnk[row][col].mcrf._add_object(modf_index)
+			self._size_changed(MCRF.entry_size, self.mcnk[row][col].mcrf.address)
+			self.mcnk[row][col].n_map_obj_refs += 1
+
+	def remove_wmo_instance(self, index):
+		if index > len(self.modf.wmo_instances) - 1:
+			raise IndexError("Index not in wmo_instances: {}".format(index))
+
+		self.modf._remove(index)
+		distance = -ADTWMODefinition.size
+		self._size_changed(distance, self.modf.address)
+
+		for row in range(16):
+			for col in range(16):
+				chunk = self.mcnk[row][col]
+				if index in chunk.mcrf.object_refs:
+					chunk.mcrf._remove_object(index)
+					self._size_changed(-MCRF.entry_size, chunk.mcrf.address)
+					chunk.n_map_obj_refs -= 1
+
+
+	# Call this whenever the size of something changes to update offsets.
+	def _size_changed(self, distance, address_of_changed):
+		self._update_offsets(distance, address_of_changed)
+		self._update_mobile_chunks(distance, address_of_changed)
+
+
+	def read(self, f):
+		self.mver.read(f)
+		if self.mver.version != 18:  # Blizzard has never cared to change it so far
+			raise NotImplementedError('Unknown ADT version: ({})'.format(self.mver.version))
+
+		self.mhdr.read(f)
+
+		f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mcin))
+		self.mcin.read(f)
+		f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mtex))
+		self.mtex.read(f)
+		f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mmdx))
+		self.mmdx.read(f)
+		f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mmid))
+		self.mmid.read(f)
+		f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mwmo))
+		self.mwmo.read(f)
+		f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mwid))
+		self.mwid.read(f)
+		f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mddf))
+		self.mddf.read(f)
+		f.seek(self.mhdr.start_data + int(self.mhdr.ofs_modf))
+		self.modf.read(f)
+		if int(self.mhdr.ofs_mfbo) and (self.mhdr.flags & ADTHeaderFlags.mhdr_MFBO):
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mfbo))
+			self.mfbo.read(f)
+
+		if int(self.mhdr.ofs_mh2o):
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mh2o))
+			self.mh2o.read(f)
+
+		if int(self.mhdr.ofs_mtxf):
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mtxf))
+			self.mtxf.read(f)
+
+		for row in range(16):
+			for col in range(16):
+				offset = int(self.mcin.entries[row*16 + col].offset)
+				f.seek(offset)
+				self.mcnk[row][col].read(f)
+
+
+	def _prune_unused_layers(self):
+		for row in range(16):
+			for col in range(16):
+				chunk = self.mcnk[row][col]
+				for i in range(len(chunk.mcal.layers), 0, -1):
+					if chunk.mcal.layers[i-1].is_fully_transparent():
+						chunk.remove_texture_layer(i)
+
+	def _prune_unused_textures(self):
+		tex_indices = [i for i in range(len(self.mtex.filenames))]
+		tex_indices.sort(reverse=True)
+
+		used_tex_indices = {}
+		for row in range(16):
+			for col in range(16):
+				chunk = self.mcnk[row][col]
+				for tex_layer in chunk.mcly.layers:
+					index = tex_layer.texture_id
+					used_tex_indices[index] = True
+		
+		for k,_ in enumerate(used_tex_indices):
+			tex_indices.remove(k)
+
+		for index in tex_indices:
+			self.remove_texture_filename(index)
+
+	def _prune_unused_M2s(self):
+		m2_indices = [i for i in range(len(self.mmdx.filenames))]
+		m2_indices.sort(reverse=True)
+
+		used_m2_indices = {}
+		for row in range(16):
+			for col in range(16):
+				chunk = self.mcnk[row][col]
+				
+				for doodad_instance in self.mddf.doodad_instances:
+					used_m2_indices[doodad_instance.name_id] = True
+
+		for k,_ in enumerate(used_m2_indices):
+			m2_indices.remove(k)
+		
+		for index in m2_indices:
+			self.remove_m2_filename(index)
+
+	def _prune_unused_WMOs(self):
+		wmo_indices = [i for i in range(len(self.mwmo.filenames))]
+		wmo_indices.sort(reverse=True)
+
+		used_wmo_indices = {}
+		for row in range(16):
+			for col in range(16):
+				chunk = self.mcnk[row][col]
+				
+				for wmo_instance in self.modf.wmo_instances:
+					used_wmo_indices[wmo_instance.name_id] = True
+
+		for k,_ in enumerate(used_wmo_indices):
+			wmo_indices.remove(k)
+		
+		for index in wmo_indices:
+			self.remove_wmo_filename(index)
+
+
+	def write(self, write_path=None, optimize=False):
+		if not write_path:
+			write_path = self.filepath
+
+		if optimize:
+			self._prune_unused_layers()
+			self._prune_unused_textures()
+			self._prune_unused_M2s()
+			self._prune_unused_WMOs()
+		
+		with open(write_path, 'wb') as f:
+			self.mver.write(f)
+			self.mhdr.write(f)
+
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mcin))
+			self.mcin.write(f)
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mtex))
+			self.mtex.write(f)
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mmdx))
+			self.mmdx.write(f)
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mmid))
+			self.mmid.write(f)
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mwmo))
+			self.mwmo.write(f)
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mwid))
+			self.mwid.write(f)
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mddf))
+			self.mddf.write(f)
+			f.seek(self.mhdr.start_data + int(self.mhdr.ofs_modf))
+			self.modf.write(f)
+
+			if int(self.mhdr.ofs_mfbo) and (self.mhdr.flags & ADTHeaderFlags.mhdr_MFBO):
+				f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mfbo))
+				self.mfbo.write(f)
+
+			if int(self.mhdr.ofs_mh2o):
+				f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mh2o))
+				self.mh2o.write(f)
+
+			if int(self.mhdr.ofs_mtxf):
+				f.seek(self.mhdr.start_data + int(self.mhdr.ofs_mtxf))
+				self.mtxf.write(f)
+
+			for row in range(16):
+				for col in range(16):
+					offset = int(self.mcin.entries[row*16 + col].offset)
+					f.seek(offset)
+					self.mcnk[row][col].write(f)

--- a/adt_file.py
+++ b/adt_file.py
@@ -151,7 +151,7 @@ class ADTFile:
 		self._remove_model_filename(index, self.mmdx, self.mmid)
 
 	def add_wmo_filename(self, filename):
-		self._add_model_filename(filename, self.mwmo, self.mwid)
+		return self._add_model_filename(filename, self.mwmo, self.mwid)
 	def replace_wmo_filename(self, index, new_filename):
 		self._replace_model_filename(index, new_filename, self.mwmo, self.mwid)
 	def remove_wmo_filename(self, index):

--- a/enums/adt_enums.py
+++ b/enums/adt_enums.py
@@ -18,6 +18,10 @@ class ADTChunkFlags(IntEnum):
 	HIGH_RES_HOLES			= 0b1 << 16
 	# +15 bits
 
+class ADTAlphaSize(IntEnum):
+	LOWRES		= 2048
+	HIGHRES		= 4096
+
 
 class ADTAlphaTypes(IntEnum):
 	#    MCLY flags    |    WDT MPHD flags    |    MCNK flags    |    mode

--- a/enums/adt_enums.py
+++ b/enums/adt_enums.py
@@ -1,27 +1,95 @@
 from enum import IntEnum
+from .. import CLIENT_VERSION, WoWVersions
 
 __reload_order_index__ = -1
 
 
 class ADTChunkFlags(IntEnum):
-    HAS_MCSH = 0x1
-    IMPASS = 0x2
-    LQ_RIVER = 0x4
-    LQ_OCEAN = 0x8
-    LQ_MAGMA = 0x10
-    LQ_SLIME = 0x20
-    HAS_MCCV = 0x40c
-    UNKNOWN = 0x80
-    DO_NOT_FIX_ALPHA_MAP = 0x8000
-    HIGH_RES_HOLES = 0x10000
+	HAS_MCSH				= 0b1 << 0
+	IMPASS					= 0b1 << 1
+	LQ_RIVER				= 0b1 << 2
+	LQ_OCEAN				= 0b1 << 3
+	LQ_MAGMA				= 0b1 << 4
+	LQ_SLIME				= 0b1 << 5
+	HAS_MCCV				= 0b1 << 6
+	UNKNOWN					= 0b1 << 7
+	# +7 bits
+	DO_NOT_FIX_ALPHA_MAP	= 0b1 << 15
+	HIGH_RES_HOLES			= 0b1 << 16
+	# +15 bits
 
 
 class ADTAlphaTypes(IntEnum):
-    BROKEN = 0
-    LOWRES = 1
-    HIGHRES = 2
-    HIGHRES_COMPRESSED = 3
+	#    MCLY flags    |    WDT MPHD flags    |    MCNK flags    |    mode
+	#------------------------------------------------------------------------------------
+	#                  |                      |                  |    "BROKEN" (2048)
+	#                  |                      |    0x8000 set    |    Uncompressed (2048)
+	#                  |    0x4 or 0x80 set   |    0x8000 set    |    Uncompressed (4096)
+	#     0x200 set    |    0x4 or 0x80 set   |    0x8000 set    |    Compressed (4096)
+	BROKEN				= 0
+	LOWRES				= 1
+	HIGHRES				= 2
+	HIGHRES_COMPRESSED	= 3
 
 
+class ADTHeaderFlags(IntEnum):
+	mhdr_MFBO		= 0b1 << 0			# contains a MFBO chunk.
+	mhdr_northrend	= 0b1 << 1			# is set for some northrend ones.
 
 
+class ADTDoodadDefinitionFlags(IntEnum):
+	mddf_biodome				= 0b1 << 0		# this sets internal flags to | 0x800 (WDOODADDEF.var0xC).
+	mddf_shrubbery				= 0b1 << 1		# the actual meaning of these is unknown to me. maybe biodome is for really big M2s. 6.0.1.18179 seems
+												# not to check  for this flag
+	mddf_unk_4					= 0b1 << 2		# Legion+ᵘ
+	mddf_unk_8					= 0b1 << 3		# Legion+ᵘ
+	#							= 0b1 << 4
+	mddf_liquidKnown			= 0b1 << 5		# Legion+ᵘ
+	mddf_entry_is_filedata_id	= 0b1 << 6		# Legion+ᵘ nameId is a file data id to directly load
+	#							= 0b1 << 7
+	mddf_unk_100				= 0b1 << 8		# Legion+ᵘ
+
+
+class ADTObjectDefinitionFlags(IntEnum):
+	modf_destroyable			= 0b1 << 0		# set for destroyable buildings like the tower in DeathknightStart. This makes it a server-controllable game object.
+	modf_use_lod				= 0b1 << 1		# WoD(?)+: also load _LOD1.WMO for use dependent on distance
+	modf_unk_has_scale			= 0b1 << 2		# Legion+: if this flag is set then use scale = scale / 1024, otherwise scale is 1.0
+	modf_entry_is_filedata_id	= 0b1 << 3		# Legion+: nameId is a file data id to directly load //SMMapObjDef::FLAG_FILEDATAID
+
+
+class ADTChunkLayerFlags(IntEnum):
+	animation_rotation0		= 0b1 << 0		# each tick is 45°
+	animation_rotation1		= 0b1 << 1
+	animation_rotation2		= 0b1 << 2
+	animation_speed0		= 0b1 << 3
+	animation_speed1		= 0b1 << 4
+	animation_speed2		= 0b1 << 5
+	animation_enabled		= 0b1 << 6
+	overbright				= 0b1 << 7		# This will make the texture way brighter. Used for lava to make it "glow".
+	use_alpha_map			= 0b1 << 8		# set for every layer after the first
+	alpha_map_compressed	= 0b1 << 9		# see MCAL chunk description
+	use_cube_map_reflection	= 0b1 << 10		# This makes the layer behave like its a reflection of the skybox. See below
+	unknown_0x800			= 0b1 << 11		# WoD?+ if either of 0x800 or 0x1000 is set, texture effects' texture_scale is applied
+	unknown_0x1000			= 0b1 << 12		# WoD?+ see 0x800
+	# +19 bits
+
+
+class ADTTextureFlags(IntEnum):
+	do_not_load_specular_or_height_texture_but_use_cubemap	= 0b1 << 0	# probably just 'disable_all_shading'
+	unused0				= 0b1 << 1		# no non-zero values in 20490
+	unused1				= 0b1 << 2		# no non-zero values in 20490
+	unused2				= 0b1 << 3		# no non-zero values in 20490
+	if CLIENT_VERSION >= WoWVersions.MOP:
+		texture_scale0	= 0b1 << 4
+		texture_scale1	= 0b1 << 5
+		texture_scale2	= 0b1 << 6
+		texture_scale3	= 0b1 << 7
+		# +24 bits						# no non-zero values in 20490
+	# else
+		# +28 unused bits				# no non-zero values in 20490
+
+
+class ADTLodLiquidDataFlags(IntEnum):
+	Flag_HasTileData	= 0b1 << 0
+	_compressed_A		= 0b1 << 1
+	_compressed_B		= 0b1 << 2

--- a/file_formats/adt_chunks.py
+++ b/file_formats/adt_chunks.py
@@ -9,597 +9,1396 @@ MAP_SIZE_MIN = -17066.66656
 MAP_SIZE_MAX = 17066.66657
 
 
+class OFFSET:
+	def __init__(self, file, ofs=0, absolute_adr=0):
+		self.ofs = ofs
+		self.absolute = absolute_adr
+		self.file = file
+		self.file._register_offset(self)
+
+	def __del__(self):
+		self.file._unregister_offset(self)
+
+	def __int__(self):
+		return self.ofs
+
+	def _update(self, distance, address_of_changed):
+		if self.absolute > address_of_changed:
+			rel_point = self.absolute - self.ofs
+			if rel_point <= address_of_changed:
+				self.ofs += distance
+			self.absolute += distance
+
+	def set(self, ofs, absolute_adr):
+		self.ofs = ofs
+		self.absolute = absolute_adr
+
+	def set_rel(self, ofs, base):
+		self.ofs = ofs
+		self.absolute = ofs + base
+
+
+class ADT_REF:
+	def __init__(self, adt):
+		self.adt = adt
+
+
+class MOBILE_CHUNK(ADT_REF):
+	def __init__(self, adt):
+		ADT_REF.__init__(self, adt)
+		self.adt._register_mobile_chunk(self)
+		self.address = 0
+
+	def set_address(self, address):
+		self.address = address
+
+	def update_address(self, distance, address_of_changed):
+		if self.address > address_of_changed:
+			self.address += distance
+
+
 class MVER:
-    def __init__(self):
-        self.header = ChunkHeader('REVM', 4)
-        self.version = 18
+	def __init__(self):
+		self.header = ChunkHeader('REVM', 4)
+		self.version = 18
 
-    def read(self, f):
-        self.header.read(f)
-        self.version = uint32.read(f)
+	def read(self, f):
+		self.header.read(f)
+		self.version = uint32.read(f)
 
-        return self
+		return self
 
-    def write(self, f):
-        self.header.write(f)
-        uint32.write(self.header)
+	def write(self, f):
+		self.header.write(f)
+		uint32.write(f, self.version)
 
-        return self
+		return self
 
 
 class MHDR:
-    def __init__(self):
-        self.header = ChunkHeader('RDHM', 54)
-        self.flags = 0
-        self.mcin = 0
-        self.mtex = 0
-        self.mmdx = 0
-        self.mmid = 0
-        self.mwmo = 0
-        self.mwid = 0
-        self.mddf = 0
-        self.modf = 0
-        self.mfbo = 0
-        self.mh2o = 0
-        self.mtxf = 0
-        self.mamp_value = 0
+	def __init__(self, adt):
+		self.header = ChunkHeader('RDHM', 54)
+		self.start_data = 0
+		self.flags = 0
+		self.ofs_mcin = OFFSET(adt)
+		self.ofs_mtex = OFFSET(adt)
+		self.ofs_mmdx = OFFSET(adt)
+		self.ofs_mmid = OFFSET(adt)
+		self.ofs_mwmo = OFFSET(adt)
+		self.ofs_mwid = OFFSET(adt)
+		self.ofs_mddf = OFFSET(adt)
+		self.ofs_modf = OFFSET(adt)
+		self.ofs_mfbo = OFFSET(adt)
+		self.ofs_mh2o = OFFSET(adt)
+		self.ofs_mtxf = OFFSET(adt)
+		self.mamp_value = 0
 
-    def read(self, f):
-        self.header.read(f)
-        pos = f.tell()
-        self.flags = uint32.read(f)
-        self.mcin = pos + uint32.read(f)
-        self.mtex = pos + uint32.read(f)
-        self.mmdx = pos + uint32.read(f)
-        self.mmid = pos + uint32.read(f)
-        self.mwmo = pos + uint32.read(f)
-        self.mwid = pos + uint32.read(f)
-        self.mddf = pos + uint32.read(f)
-        self.modf = pos + uint32.read(f)
-        self.mfbo = pos + uint32.read(f)
-        self.mh2o = pos + uint32.read(f)
-        self.mtxf = pos + uint32.read(f)
-        self.mamp_value = uint8.read(f)
-        f.skip(15)
+	def read(self, f):
+		self.header.read(f)
+		self.start_data = f.tell()
+		self.flags = uint32.read(f)
+		self.ofs_mcin.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mtex.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mmdx.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mmid.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mwmo.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mwid.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mddf.set_rel(uint32.read(f), self.start_data)
+		self.ofs_modf.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mfbo.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mh2o.set_rel(uint32.read(f), self.start_data)
+		self.ofs_mtxf.set_rel(uint32.read(f), self.start_data)
+		self.mamp_value = uint8.read(f)
 
-        return self
+		return self
 
-    def write(self, f):
-        self.header.write(f)
-        pos = f.tell()
-        uint32.write(f, self.flags)
-        uint32.write(f, pos + self.mcin)
-        uint32.write(f, pos + self.mtex)
-        uint32.write(f, pos + self.mmdx)
-        uint32.write(f, pos + self.mmid)
-        uint32.write(f, pos + self.mwmo)
-        uint32.write(f, pos + self.mwid)
-        uint32.write(f, pos + self.mddf)
-        uint32.write(f, pos + self.modf)
-        uint32.write(f, pos + self.mfbo)
-        uint32.write(f, pos + self.mh2o)
-        uint32.write(f, pos + self.mtxf)
-        uint8.write(f, self.mamp_value)
-        f.skip(15)
+	def write(self, f):
+		self.header.write(f)
+		pos = f.tell()
+		uint32.write(f, self.flags)
+		uint32.write(f, int(self.ofs_mcin))
+		uint32.write(f, int(self.ofs_mtex))
+		uint32.write(f, int(self.ofs_mmdx))
+		uint32.write(f, int(self.ofs_mmid))
+		uint32.write(f, int(self.ofs_mwmo))
+		uint32.write(f, int(self.ofs_mwid))
+		uint32.write(f, int(self.ofs_mddf))
+		uint32.write(f, int(self.ofs_modf))
+		uint32.write(f, int(self.ofs_mfbo))
+		uint32.write(f, int(self.ofs_mh2o))
+		uint32.write(f, int(self.ofs_mtxf))
+		uint8.write(f, self.mamp_value)
 
-        return self
-
-
-class MCIN:
-    def __init__(self):
-        self.header = ChunkHeader('NICM', 16)
-        self.offset = 0
-        self.size = 0
-
-    def read(self, f):
-        self.header.read(f)
-        self.offset = uint32.read(f)
-        self.size = uint32.read(f)
-        f.skip(8)
-
-        return self
-
-    def write(self, f):
-        self.header.write(f)
-        uint32.write(f, self.header)
-        uint32.write(f, self.size)
-        f.skip(8)
-
-        return self
+		return self
 
 
-class MTEX(StringBlockChunk):
-    magic = 'XTEM'
+class MCIN_entry:
+	def __init__(self, adt):
+		self.offset = OFFSET(adt)
+		self.size = 0
+		self.flags = 0
+		self.async_id = 0
+
+	def read(self, f):
+		self.offset.set_rel(uint32.read(f), 0)
+		self.size = uint32.read(f)
+		self.flags = uint32.read(f)
+		self.async_id = uint32.read(f)
+
+		return self
+
+	def write(self, f):
+		uint32.write(f, int(self.offset))
+		uint32.write(f, self.size)
+		uint32.write(f, self.flags)
+		uint32.write(f, self.async_id)
+
+		return self
 
 
-class MMID:
-    def __init__(self):
-        self.header = ChunkHeader('DIMM')
-        self.offsets = []
 
-    def read(self, f):
-        self.header.read(f)
+class MCIN(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('NICM', 16)
+		self.entries = [MCIN_entry(adt) for _ in range(256)]
 
-        for _ in range(self.header.size // 4):
-            self.offsets.append(uint32.read(f))
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		for entry in self.entries:
+			entry.read(f)
 
-        return self
+		return self
 
-    def write(self, f):
-        self.header.size = len(self.offsets) * 4
-        self.header.write(f)
+	def write(self, f):
+		self.header.size = len(self.entries) * 16
+		self.header.write(f)
 
-        for offset in self.offsets:
-            uint32.write(offset)
+		for entry in self.entries:
+			entry.write(f)
 
-        return self
+		return self
 
 
-class MWID:
-    def __init__(self):
-        self.header = ChunkHeader('DIWM')
-        self.offsets = []
+class MTEX(MOBILE_CHUNK, StringBlockChunk):
+	magic = 'XTEM'
 
-    def read(self, f):
-        self.header.read(f)
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		StringBlockChunk.__init__(self)
 
-        for _ in range(self.header.size // 4):
-            self.offsets.append(uint32.read(f))
+	def read(self, f):
+		self.set_address(f.tell())
+		StringBlockChunk.read(self, f)
 
-    def write(self, f):
-        self.header.size = len(self.offsets) * 4
-        self.header.write(f)
 
-        for offset in self.offsets:
-            uint32.write(offset)
+class MMDX(MOBILE_CHUNK, StringBlockChunk):
+	magic = 'XDMM'
+
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		StringBlockChunk.__init__(self)
+	def read(self, f):
+		self.set_address(f.tell())
+		StringBlockChunk.read(self, f)
+
+
+class MMID(MOBILE_CHUNK):
+	entry_size = 4
+
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('DIMM')
+		self.offsets = []
+
+	def _add(self, ofs):
+		abs_ofs = ofs + self.adt._get_mmdx_data_start()
+		ofs = OFFSET(self.adt, ofs, abs_ofs)
+		self.offsets.append(ofs)
+
+	def _remove(self, index):
+		del self.offsets[index]
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+
+		for _ in range(self.header.size // MMID.entry_size):
+			ofs = uint32.read(f)
+			abs_ofs = ofs + self.adt._get_mmdx_data_start()
+			self.offsets.append(OFFSET(self.adt, ofs, abs_ofs))
+
+		return self
+
+	def write(self, f):
+		self.header.size = len(self.offsets) * MMID.entry_size
+		self.header.write(f)
+
+		for offset in self.offsets:
+			uint32.write(f, int(offset))
+
+		return self
+
+
+class MWMO(MOBILE_CHUNK, StringBlockChunk):
+	magic = 'OMWM'
+
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		StringBlockChunk.__init__(self)
+	def read(self, f):
+		self.set_address(f.tell())
+		StringBlockChunk.read(self, f)
+
+
+class MWID(MOBILE_CHUNK):
+	entry_size = 4
+
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('DIWM')
+		self.offsets = []
+
+	def _add(self, ofs):
+		abs_ofs = ofs + self.adt._get_mwmo_data_start()
+		ofs = OFFSET(self.adt, ofs, abs_ofs)
+		self.offsets.append(ofs)
+
+	def _remove(self, index):
+		del self.offsets[index]
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+
+		for _ in range(self.header.size // MWID.entry_size):
+			ofs = uint32.read(f)
+			abs_ofs = ofs + self.adt._get_mwmo_data_start()
+			self.offsets.append(OFFSET(self.adt, ofs, abs_ofs))
+
+	def write(self, f):
+		self.header.size = len(self.offsets) * MWID.entry_size
+		self.header.write(f)
+
+		for offset in self.offsets:
+			uint32.write(f, int(offset))
 
 
 class ADTDoodadDefinition:
-    def __init__(self):
-        self.name_id = 0
-        self.unique_id = 0
-        self.position = (0, 0, 0)
-        self.rotation = (0, 0, 0)
-        self.scale = 0
-        self.flags = 0
+	size = 36
 
-    def read(self, f):
-        self.name_id = uint32.read(f)
-        self.unique_id = uint32.read(f)
-        self.position = vec3D.read(f)
-        self.rotation = vec3D.read(f)
-        self.scale = uint16.read(f)
-        self.flags = uint16.read(f)
+	def __init__(self, name_id=0, unique_id=0, position=None, rotation=None, scale=0, flags=0):
+		if position is None:
+			position = C3Vector()
+		if rotation is None:
+			rotation = C3Vector()
+		self.name_id = name_id
+		self.unique_id = unique_id
+		self.position = position
+		self.rotation = rotation
+		self.scale = scale
+		self.flags = flags
 
-        return self
+	def read(self, f):
+		self.name_id = uint32.read(f)
+		self.unique_id = uint32.read(f)
+		self.position.read(f)
+		self.rotation.read(f)
+		# self.position = vec3D.read(f)
+		# self.rotation = vec3D.read(f)
+		self.scale = uint16.read(f)
+		self.flags = uint16.read(f)
 
-    def write(self, f):
-        uint32.write(f, self.name_id)
-        uint32.write(f, self.unique_id)
-        vec3D.write(f, self.position)
-        vec3D.write(f, self.rotation)
-        uint16.write(f, self.scale)
-        uint16.write(f, self.flags)
+		return self
 
-        return self
+	def write(self, f):
+		uint32.write(f, self.name_id)
+		uint32.write(f, self.unique_id)
+		self.position.write(f)
+		self.rotation.write(f)
+		# vec3D.write(f, self.position)
+		# vec3D.write(f, self.rotation)
+		uint16.write(f, self.scale)
+		uint16.write(f, self.flags)
+
+		return self
 
 
-class MDDF:
-    def __init__(self):
-        self.header = ChunkHeader('FDDM')
-        self.doodad_instances = []
+class MDDF(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('FDDM')
+		self.doodad_instances = []
 
-    def read(self, f):
-        self.header.read(f)
-        for _ in range(self.header.size // 36):
-            self.doodad_instances.append(ADTDoodadDefinition().read(f))
+	def _add(self, name_id, unique_id, position, rotation, scale, flags):
+		if type(position) != C3Vector:
+			position = C3Vector(position)
+		if type(rotation) != C3Vector:
+			rotation = C3Vector(rotation)
+		dad = ADTDoodadDefinition(name_id, unique_id, position, rotation, scale, flags)
+		self.doodad_instances.append(dad)
 
-    def write(self, f):
-        self.header.size = len(self.doodad_instances) * 36
-        self.header.write(f)
+	def _remove(self, index):
+		del self.doodad_instances[index]
 
-        for doodad in self.doodad_instances:
-            doodad.write(f)
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		for _ in range(self.header.size // ADTDoodadDefinition.size):
+			self.doodad_instances.append(ADTDoodadDefinition().read(f))
+
+	def write(self, f):
+		self.header.size = len(self.doodad_instances) * ADTDoodadDefinition.size
+		self.header.write(f)
+
+		for doodad in self.doodad_instances:
+			doodad.write(f)
 
 
 class ADTWMODefinition:
-    def __init__(self):
-        self.name_id = 0
-        self.unique_id = 0
-        self.position = (0.0, 0.0, 0.0)
-        self.rotation = (0.0, 0.0, 0.0)
-        self.extents = CAaBox()
-        self.flags = 0
-        self.doodad_set = 0
-        self.name_set = 0
-        self.scale = 0
+	size = 64
 
-    def read(self, f):
-        self.name_id = uint32.read(f)
-        self.unique_id = uint32.read(f)
-        self.position = vec3D.read(f)
-        self.rotation = vec3D.read(f)
-        self.extents.read(f)
-        self.flags = uint16.read(f)
-        self.doodad_set = uint16.read(f)
-        self.name_set = uint16.read(f)
-        self.scale = uint16.read(f)
+	def __init__(self, name_id=0, unique_id=0, position=None, rotation=None, 
+				extents=None, flags=0, doodad_set=0, name_set=0, scale=0):
+		if position is None:
+			position = C3Vector()
+		if rotation is None:
+			rotation = C3Vector()
+		if extents is None:
+			extents = CAaBox()
+		self.name_id = name_id
+		self.unique_id = unique_id
+		self.position = position
+		self.rotation = rotation
+		self.extents = extents
+		self.flags = flags
+		self.doodad_set = doodad_set
+		self.name_set = name_set
+		self.scale = scale
 
-    def write(self, f):
-        uint32.write(f, self.name_id)
-        uint32.write(f, self.unique_id)
-        vec3D.write(f, self.position)
-        vec3D.write(f, self.rotation)
-        self.extents.write(f)
-        uint16.write(f, self.flags)
-        uint16.write(f, self.doodad_set)
-        uint16.write(f, self.name_set)
-        uint16.write(f, self.scale)
+	def read(self, f):
+		self.name_id = uint32.read(f)
+		self.unique_id = uint32.read(f)
+		# self.position = vec3D.read(f)
+		# self.rotation = vec3D.read(f)
+		self.position.read(f)
+		self.rotation.read(f)
+		self.extents.read(f)
+		self.flags = uint16.read(f)
+		self.doodad_set = uint16.read(f)
+		self.name_set = uint16.read(f)
+		self.scale = uint16.read(f)
 
-
-class MODF:
-    def __init__(self):
-        self.header = ChunkHeader('FDOM')
-        self.wmo_instances = []
-
-    def read(self, f):
-        self.header.read(f)
-        for _ in range(self.header.size // 64):
-            wmo_instance = ADTWMODefinition()
-            wmo_instance.read(f)
-            self.wmo_instances.append(wmo_instance)
-
-    def write(self, f):
-        self.header.size = len(self.wmo_instances) * 64
-        self.header.write(f)
-
-        for wmo_instance in self.wmo_instances:
-            wmo_instance.write(f)
+	def write(self, f):
+		uint32.write(f, self.name_id)
+		uint32.write(f, self.unique_id)
+		# vec3D.write(f, self.position)
+		# vec3D.write(f, self.rotation)
+		self.position.write(f)
+		self.rotation.write(f)
+		self.extents.write(f)
+		uint16.write(f, self.flags)
+		uint16.write(f, self.doodad_set)
+		uint16.write(f, self.name_set)
+		uint16.write(f, self.scale)
 
 
-class MCNK:
-    def __init__(self):
-        self.header = ChunkHeader('KNCM')
-        self.index_x = 0
-        self.index_y = 0
-        self.n_layers = 0
-        self.n_doodad_refs = 0
+class MODF(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('FDOM')
+		self.wmo_instances = []
 
-        if CLIENT_VERSION >= WoWVersions.MOP:
-            self.hole_high_res = 0
-        else:
-            self.ofs_height = 0
-            self.ofs_normal = 0
+	def _add(self, name_id, unique_id, position, rotation, 
+			extents, flags, doodad_set, name_set, scale):
+		if type(position) != C3Vector:
+			position = C3Vector(position)
+		if type(rotation) != C3Vector:
+			rotation = C3Vector(rotation)
+		if type(extents) != CAaBox:
+			extents = CAaBox(*extents)
+		wmo = ADTWMODefinition(name_id, unique_id, position, rotation, 
+			extents, flags, doodad_set, name_set, scale)
+		self.wmo_instances.append(wmo)
 
-        self.ofs_layer = 0
-        self.ofs_refs = 0
-        self.ofs_alpha = 0
-        self.size_alpha = 0
-        self.ofs_shadow = 0
-        self.size_shadow = 0
-        self.area_id = 0
-        self.n_map_obj_refs = 0
-        self.holes_low_res = 0
-        self.unknown_but_used = 0
-        self.low_quality_texture_map = []
+	def _remove(self, index):
+		del self.wmo_instances[index]
 
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		for _ in range(self.header.size // ADTWMODefinition.size):
+			wmo_instance = ADTWMODefinition()
+			wmo_instance.read(f)
+			self.wmo_instances.append(wmo_instance)
 
-class MCVT:
-    def __init__(self):
-        self.header = ChunkHeader('TVCM', 580)
-        self.height = [0.0] * 145
+	def write(self, f):
+		self.header.size = len(self.wmo_instances) * ADTWMODefinition.size
+		self.header.write(f)
 
-    def read(self, f):
-        self.header.read(f)
-        self.height = [float32.read(f) for _ in range(145)]
-
-    def write(self, f):
-        self.header.write(f)
-        for value in self.height: float32.write(value)
+		for wmo_instance in self.wmo_instances:
+			wmo_instance.write(f)
 
 
-class MCLV:
-    def __init__(self):
-        self.header = ChunkHeader('VLCM', 580)
-        self.colors = [(255, 255, 255, 255)] * 145
+class MFBO(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('OBFM')
+		self.maximum = [[0] * 3] * 3
+		self.minimum = [[0] * 3] * 3
 
-    def read(self, f):
-        self.header.read(f)
-        self.colors = [uint8.read(f, 4) for _ in range(145)]
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.maximum = [[int16.read(f) for _ in range(3)] for _ in range(3)]
+		self.minimum = [[int16.read(f) for _ in range(3)] for _ in range(3)]
 
-    def write(self, f):
-        self.header.write(f)
-        for value in self.colors: uint8.write(f, value, 4)
-
-
-class MCCV:
-    def __init__(self):
-        self.header = ChunkHeader('VCCM', 580)
-        self.colors = [(255, 255, 255, 255)] * 145
-
-    def read(self, f):
-        self.header.read(f)
-        self.colors = [uint8.read(f, 4) for _ in range(145)]
-
-    def write(self, f):
-        self.header.write(f)
-        for value in self.colors: uint8.write(f, value, 4)
+	def write(self, f):
+		self.header.write(f)
+		for r in self.maximum:
+			for h in r:
+				int16.write(f, h)
+		for r in self.minimum:
+			for h in r:
+				int16.write(f, h)
 
 
-class MCNR:
-    def __init__(self):
-        self.header = ChunkHeader('RNCM', 435 if CLIENT_VERSION <= WoWVersions.WOTLK else 448)
-        self.normals = [(0, 0, 0)] * 145
+# class SMLiquidChunk:
+#     def __init__(self):
+#         self.offset_instances = 0
+#         self.layer_count = 0
+#         self.offset_attributes = 0
 
-    def read(self, f):
-        self.header.read(f)
-        self.normals = [int8.read(f, 3) for _ in range(145)]
-        f.skip(13)
+#     def read(self, f):
+#         self.offset_instances = uint32.read(f)
+#         self.layer_count = uint32.read(f)
+#         self.offset_attributes = uint32.read(f)
 
-    def write(self, f):
-        self.header.write(f)
-        for normal in self.normals: int8.write(f, normal, 3)
-        f.skip(13)  # TODO: write original data here
+#     def write(self, f):
+#         uint32.write(f, self.offset_instances)
+#         uint32.write(f, self.layer_count)
+#         uint32.write(f, self.offset_attributes)
+
+
+# class mh2o_chunk_attributes:
+#     def __init__(self):
+#         self.fishable = 0
+#         self.deep = 0
+
+#     def read(self, f):
+#         self.fishable = uint64.read(f)
+#         self.deep = uint64.read(f)
+
+#     def write(self, f):
+#         uint64.write(f, self.fishable)
+#         uint64.write(f, self.deep)
+
+
+# class MH2O:
+#     def __init__(self):
+#         self.header = ChunkHeader('O2HM')
+#         self.chunks = [SMLiquidChunk() for _ in range(256)]
+#         self.liquid_instances = []
+
+#     def read(self, f):
+#         self.header.read(f)
+#         for chunk in self.chunks:
+#             chunk.read()
+
+#     def write(self, f):
+class MH2O(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('O2HM')
+		# TODO
+		self.data = []
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.data = [uint8.read(f) for _ in range(self.header.size)]
+
+	def write(self, f):
+		self.header.size = len(self.data)
+		self.header.write(f)
+		for c in self.data:
+			uint8.write(f, c)
+
+
+class MTXF(MOBILE_CHUNK):
+	entry_size = 4
+
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('FXTM')
+		self.flags = []
+
+	def _add(self, flags):
+		self.flags.append(flags)
+	
+	def _remove(self, index):
+		del self.flags[index]
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		for _ in range(self.header.size // MTXF.entry_size):
+			self.flags.append(uint32.read(f))
+
+	def write(self, f):
+		self.header.size = len(self.flags) * MTXF.entry_size
+		self.header.write()
+		for flag in self.flags:
+			flag.write(f)
+
+
+class MCNK(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('KNCM')
+		self.flags = 0
+		self.index_x = 0
+		self.index_y = 0
+		self.n_layers = 0
+		self.n_doodad_refs = 0
+
+		if CLIENT_VERSION >= WoWVersions.MOP:
+			self.hole_high_res = 0
+		else:
+			self.ofs_mcvt = OFFSET(self.adt)
+			self.ofs_mcnr = OFFSET(self.adt)
+
+		self.ofs_mcly = OFFSET(self.adt)
+		self.ofs_mcrf = OFFSET(self.adt)
+		self.ofs_mcal = OFFSET(self.adt)
+		self.size_mcal = 0
+		self.ofs_mcsh = OFFSET(self.adt)
+		self.size_mcsh = 0
+		self.area_id = 0
+		self.n_map_obj_refs = 0
+		self.holes_low_res = 0
+		self.unknown_but_used = 0
+		self.low_quality_texture_map = [[0] * 8] * 8
+		self.no_effect_doodad = [[0] * 8] * 8
+		self.ofs_mcse = OFFSET(self.adt)
+		self.n_sound_emitters = 0
+		self.ofs_mclq = OFFSET(self.adt)
+		self.size_mclq = 0
+		self.position = C3Vector()
+		self.ofs_mccv = OFFSET(self.adt)
+		self.ofs_mclv = OFFSET(self.adt)
+		self.unused = 0
+
+		self.mcvt = MCVT(adt)
+		self.mcnr = MCNR(adt)
+		self.mcly = MCLY(adt, self)
+		self.mcrf = MCRF(adt)
+		self.mcal = MCAL(adt)
+		self.mcsh = MCSH(adt)
+		self.mcse = MCSE(adt)
+		# self.mclq = MCLQ(adt)    # TODO
+		self.mccv = MCCV(adt)
+		self.mclv = MCLV(adt)
+
+	def _get_mcal_data_start(self):
+		return self.address + int(self.ofs_mcal) + ChunkHeader.size
+
+	def add_sound_emitter(self, entry_id, position, size):
+		if position is not C3Vector:
+			position = C3Vector(position)
+		if size is not C3Vector:
+			size = C3Vector(size)
+		self.mcse._add_entry(entry_id, position, size)
+		self.n_sound_emitters += 1
+
+	def remove_sound_emitter(self, index):
+		if index > len(self.mcse.entries) - 1:
+			raise IndexError("Index not in entries: {}".format(index))
+		
+		self.mcse._remove_entry(index)
+		self.n_sound_emitters -= 1
+
+	def add_texture_layer(self, texture_id, flags, effect_id, alpha_is_highres):
+		if self.n_layers >= 4:
+			raise Exception("Chunk already has max texture layers.")
+
+		self.n_layers += 1
+		ofs = 0
+		adr = 0
+		if self.n_layers > 1:
+			alpha_is_broken = not (self.flags & ADTChunkFlags.DO_NOT_FIX_ALPHA_MAP)
+			alpha_is_compressed = flags & ADTChunkLayerFlags.alpha_map_compressed
+			alpha_type = None
+			
+			if alpha_is_highres:
+				if alpha_is_compressed[i]:
+					alpha_type = ADTAlphaTypes.HIGHRES_COMPRESSED
+				else:
+					alpha_type = ADTAlphaTypes.HIGHRES
+			else:
+				if alpha_is_broken:
+					alpha_type = ADTAlphaTypes.BROKEN
+				else:
+					alpha_type = ADTAlphaTypes.LOWRES
+			
+			ofs = self.mcal._add_layer(alpha_type)
+			adr = ofs + self.mcal.address + ChunkHeader.size
+		offset_in_mcal = OFFSET(self.adt, ofs, adr)
+		self.mcly._add_layer(texture_id, flags, offset_in_mcal, effect_id)
+	
+	def remove_texture_layer(self, index):
+		if index >= len(self.mcly.layers) or index < 0:
+			raise IndexError("Index not in layers: {}".format(index))
+
+		if len(self.mcly.layers) > 1:
+			index_in_mcal = index
+			if index > 0:
+				index_in_mcal -= 1
+			
+			address = self.mcly.layers[index].offset_in_mcal.absolute
+			self.mcal._remove_layer(index_in_mcal, address)
+
+		self.mcly._remove_layer(index)
+
+		if index == 0 and len(self.mcly.layers) > 0:
+			self.mcly.layers[0].flags &= ~(ADTChunkLayerFlags.use_alpha_map)
+		
+		self.n_layers -= 1
+
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.flags = uint32.read(f)
+		self.index_x = uint32.read(f)
+		self.index_y = uint32.read(f)
+		self.n_layers = uint32.read(f)
+		self.n_doodad_refs = uint32.read(f)
+
+		if CLIENT_VERSION >= WoWVersions.MOP:
+			self.hole_high_res = uint64.read(f)
+		else:
+			self.ofs_mcvt.set_rel(uint32.read(f), self.address)
+			self.ofs_mcnr.set_rel(uint32.read(f), self.address)
+
+		self.ofs_mcly.set_rel(uint32.read(f), self.address)
+		self.ofs_mcrf.set_rel(uint32.read(f), self.address)
+		self.ofs_mcal.set_rel(uint32.read(f), self.address)
+		self.size_mcal = uint32.read(f)
+		self.ofs_mcsh.set_rel(uint32.read(f), self.address)
+		self.size_mcsh = uint32.read(f)
+		self.area_id = uint32.read(f)
+		self.n_map_obj_refs = uint32.read(f)
+		self.holes_low_res = uint16.read(f)
+		self.unknown_but_used = uint16.read(f)
+
+		for i in range(8):
+			self.low_quality_texture_map[i] = []
+			for _ in range(2):
+				b = uint8.read(f)
+				self.low_quality_texture_map[i] += uint8_to_uint2_list(b)
+
+		for i in range(8):
+			b = uint8.read(f)
+			self.no_effect_doodad[i] = uint8_to_uint1_list(b)
+
+		self.ofs_mcse.set_rel(uint32.read(f), self.address)
+		self.n_sound_emitters = uint32.read(f)
+		self.ofs_mclq.set_rel(uint32.read(f), self.address)
+		self.size_liquid = uint32.read(f)
+		self.position.read(f)
+		self.ofs_mccv.set_rel(uint32.read(f), self.address)
+		self.ofs_mclv.set_rel(uint32.read(f), self.address)
+		self.unused = uint32.read(f)
+
+		f.seek(self.address + int(self.ofs_mcvt))
+		self.mcvt.read(f)
+		f.seek(self.address + int(self.ofs_mcnr))
+		self.mcnr.read(f)
+		f.seek(self.address + int(self.ofs_mcly))
+		self.mcly.read(f)
+		f.seek(self.address + int(self.ofs_mcrf))
+		self.mcrf.read(f, self.n_doodad_refs, self.n_map_obj_refs)
+
+		alpha_is_broken = not (self.flags & ADTChunkFlags.DO_NOT_FIX_ALPHA_MAP)
+		alpha_is_compressed = []
+		for layer in self.mcly.layers:
+			is_comp = layer.flags & ADTChunkLayerFlags.alpha_map_compressed
+			alpha_is_compressed.append(is_comp)
+		f.seek(self.address + int(self.ofs_mcal))
+		self.mcal.read(f, self.n_layers, alpha_is_broken, alpha_is_compressed)
+
+		if (self.flags & ADTChunkFlags.HAS_MCSH):
+			f.seek(self.address + int(self.ofs_mcsh))
+			self.mcsh.read(f)
+
+		f.seek(self.address + int(self.ofs_mcse))
+		self.mcse.read(f, self.n_sound_emitters)
+
+		# TODO: (DEPRECATED)
+		# if self.ofs_mclq:
+		# 	f.seek(self.start + self.ofs_mclq)
+		# 	self.mclq.read(f)
+
+		if (self.flags & ADTChunkFlags.HAS_MCCV):
+			f.seek(self.address + int(self.ofs_mccv))
+			self.mccv.read(f)
+
+		# TODO
+		# f.seek(self.start + self.ofs_mclv)
+		# self.mclv.read(f)
+
+	def _set_header_size(self):
+		size = 0
+
+		# MCNK header
+		size += 128
+
+		# MCVT
+		size += ChunkHeader.size
+		size += self.mcvt.header.size
+
+		# MCNR
+		size += ChunkHeader.size
+		size += self.mcnr.header.size
+		size += 13		# "unkshit"
+
+		# MCLY
+		size += ChunkHeader.size
+		for layer in self.mcly.layers:
+			size += MCLYLayer.size
+
+		# MCRF
+		size += ChunkHeader.size
+		for entry in self.mcrf.doodad_refs:
+			size += MCRF.entry_size
+		for entry in self.mcrf.object_refs:
+			size += MCRF.entry_size
+
+		# MCSH
+		if self.flags & ADTChunkFlags.HAS_MCSH:
+			size += ChunkHeader.size
+			size += self.mcsh.header.size
+
+		# MCAL
+		size += ChunkHeader.size
+		for layer in self.mcal.layers:
+			size += layer.size
+
+		# MCSE
+		size += ChunkHeader.size
+		for entry in self.mcse.entries:
+			size += MCSESoundEmitter.size
+
+		# MCCV
+		if self.flags & ADTChunkFlags.HAS_MCCV:
+			size += ChunkHeader.size
+			size += self.mccv.header.size
+
+		self.header.size = size
+
+	def write(self, f):
+		self._set_header_size()
+		self.header.write(f)
+		uint32.write(f, self.flags)
+		uint32.write(f, self.index_x)
+		uint32.write(f, self.index_y)
+		uint32.write(f, self.n_layers)
+		uint32.write(f, self.n_doodad_refs)
+
+		if CLIENT_VERSION >= WoWVersions.MOP:
+			uint64.write(f, self.hole_high_res)
+		else:
+			uint32.write(f, int(self.ofs_mcvt))
+			uint32.write(f, int(self.ofs_mcnr))
+
+		uint32.write(f, int(self.ofs_mcly))
+		uint32.write(f, int(self.ofs_mcrf))
+		uint32.write(f, int(self.ofs_mcal))
+		uint32.write(f, self.size_mcal)
+		uint32.write(f, int(self.ofs_mcsh))
+		uint32.write(f, self.size_mcsh)
+		uint32.write(f, self.area_id)
+		uint32.write(f, self.n_map_obj_refs)
+		uint16.write(f, self.holes_low_res)
+		uint16.write(f, self.unknown_but_used)
+
+		for i in range(8):
+			b = uint2_list_to_uint8(self.low_quality_texture_map[i][0:4])
+			uint8.write(f, b)
+			b = uint2_list_to_uint8(self.low_quality_texture_map[i][4:])
+			uint8.write(f, b)
+
+		for i in range(8):
+			b = uint1_list_to_uint8(self.no_effect_doodad[i])
+			uint8.write(f, b)
+
+		uint32.write(f, int(self.ofs_mcse))
+		uint32.write(f, self.n_sound_emitters)
+		uint32.write(f, int(self.ofs_mclq))
+		uint32.write(f, self.size_liquid)
+		self.position.write(f)
+		uint32.write(f, int(self.ofs_mccv))
+		uint32.write(f, int(self.ofs_mclv))
+		uint32.write(f, self.unused)
+
+		f.seek(self.address + int(self.ofs_mcvt))
+		self.mcvt.write(f)
+		f.seek(self.address + int(self.ofs_mcnr))
+		self.mcnr.write(f)
+		f.seek(self.address + int(self.ofs_mcly))
+		self.mcly.write(f)
+		f.seek(self.address + int(self.ofs_mcrf))
+		self.mcrf.write(f)
+
+		f.seek(self.address + int(self.ofs_mcal))
+		self.mcal.write(f)
+
+		if (self.flags & ADTChunkFlags.HAS_MCSH):
+			f.seek(self.address + int(self.ofs_mcsh))
+			self.mcsh.write(f)
+
+		f.seek(self.address + int(self.ofs_mcse))
+		self.mcse.write(f)
+
+		# if self.ofs_mclq:
+		# 	f.seek(self.start + self.ofs_mclq)
+		# 	self.mclq.read(f)
+
+		if (self.flags & ADTChunkFlags.HAS_MCCV):
+			f.seek(self.address + int(self.ofs_mccv))
+			self.mccv.write(f)
+
+		# f.seek(self.start + self.ofs_mclv)
+		# self.mclv.read(f)
+
+
+class MCVT(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('TVCM', 580)
+		self.height = [0.0] * 145
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.height = [float32.read(f) for _ in range(145)]
+
+	def write(self, f):
+		self.header.write(f)
+		for value in self.height: float32.write(f, value)
+
+
+class MCLV(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('VLCM', 580)
+		self.colors = [(255, 255, 255, 255)] * 145
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.colors = [uint8.read(f, 4) for _ in range(145)]
+
+	def write(self, f):
+		self.header.write(f)
+		for value in self.colors: uint8.write(f, value, 4)
+
+
+class MCCV(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('VCCM', 580)
+		self.colors = [(255, 255, 255, 255)] * 145
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.colors = [uint8.read(f, 4) for _ in range(145)]
+
+	def write(self, f):
+		self.header.write(f)
+		for value in self.colors: uint8.write(f, value, 4)
+
+
+class MCNR(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('RNCM', 435 if CLIENT_VERSION <= WoWVersions.WOTLK else 448)
+		self.normals = [(0, 0, 0)] * 145
+		self.unknown = [0] * 13
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.normals = [int8.read(f, 3) for _ in range(145)]
+		self.unknown = uint8.read(f, 13)
+
+	def write(self, f):
+		self.header.write(f)
+		for normal in self.normals: int8.write(f, normal, 3)
+		for unk in self.unknown: uint8.write(f, unk)
 
 
 class MCLYLayer:
-    def __init__(self):
-        self.texture_id = 0
-        self.flags = 0
-        self.offset_in_mcal = 0
-        self.effect_id = 0
-
-    def read(self, f):
-        self.texture_id = uint32.read(f)
-        self.flags = uint32.read(f)
-        self.offset_in_mcal = uint32.read(f)
-        self.effect_id = uint32.read(f)
-
-    def write(self, f):
-        uint32.write(f, self.texture_id)
-        uint32.write(f, self.flags)
-        uint32.write(f, self.offset_in_mcal)
-        uint32.write(f, self.effect_id)
-
-
-class MCLY:
-    def __init__(self):
-        self.header = ChunkHeader('YLCM')
-        self.layers = []
-
-    def read(self, f):
-        self.header.read(f)
-
-        for _ in range(self.header.size // 16):
-            layer = MCLYLayer()
-            layer.read(f)
-            self.layers.append(layer)
-
-    def write(self, f):
-        self.header.size = len(self.layers * 16)
-        self.header.write(f)
-
-        for layer in self.layers:
-            layer.write(f)
-
-
-class MCRF:
-    def __init__(self):
-        self.header = ChunkHeader('MCRF')
-        self.doodad_refs = []
-        self.object_refs = []
-
-    def read(self, f, n_doodad_refs, n_object_refs):
-        self.header.read(f)
-        self.doodad_refs = [uint32.read(f) for _ in range(n_doodad_refs)]
-        self.object_refs = [uint32.read(f) for _ in range(n_object_refs)]
-
-    def write(self, f):
-        n_doodad_refs = len(self.doodad_refs)
-        n_object_refs = len(self.object_refs)
-        self.header.size = n_doodad_refs * 4 + n_object_refs * 4
-        self.header.write(f)
-
-        uint32.write(f, self.doodad_refs, n_doodad_refs)
-        uint32.write(f, self.object_refs, n_object_refs)
-
-
-class MCSH:
-    def __init__(self):
-        self.header = ChunkHeader('HSCM', 512)
-        self.shadow_map = [[0 for _ in range(64)] for _ in range(64)]
-
-    def read(self, f):
-        self.header.read(f)
-        f.skip(512)  # TODO: implement
-
-    def write(self, f):
-        self.header.write(f)
-        f.skip(512)
-
-
-class MCAL:
-    def __init__(self, type):
-        self.header = ChunkHeader('LACM')
-        self.type = type
-        self.alpha_map = [[0 for _ in range(64)] for _ in range(64)]
-
-    def read(self, f):
-        if self.type in (ADTAlphaTypes.LOWRES, ADTAlphaTypes.BROKEN):
-            cur_pos = 0
-            alpha_map_flat = [0] * 4096
-
-            for i in range(2048):
-                cur_byte = uint8.read(f)
-                nibble1 = cur_byte & 0x0F
-                nibble2 = (cur_byte & 0xF0) >> 4
-
-                first = nibble1 * 255 // 15
-                second = nibble2 * 255 // 15
-
-                alpha_map_flat[i + cur_pos + 0] = first
-                alpha_map_flat[i + cur_pos + 1] = second
-                cur_pos += 1
-
-            self.alpha_map = [[alpha_map_flat[i * j] for i in range(64)] for j in range(64)]
-
-            if self.type == ADTAlphaTypes.BROKEN:
-                for row in self.alpha_map:
-                    row[63] = row[62]
-
-                for i, column in enumerate(self.alpha_map[62]):
-                    self.alpha_map[63][i] = column
-
-        elif self.type == ADTAlphaTypes.HIGHRES:
-            self.alpha_map = [[uint8.read(f) for _ in range(64)] for _ in range(64)]
-
-        elif self.type == ADTAlphaTypes.HIGHRES_COMPRESSED:
-            alpha_map_flat = [0] * 4096
-            alpha_offset = 0
-
-            while alpha_offset < 4096:
-                cur_byte = uint8.read(f)
-                mode = bool(cur_byte >> 7)
-                count = cur_byte & 0b1111111
-
-                if mode:  # fill
-                    alpha = uint8.read(f)
-                    for i in range(count):
-                        alpha_map_flat[alpha_offset] = alpha
-                        alpha_offset += 1
-                else:  # copy
-                    for i in range(count):
-                        alpha_map_flat[alpha_offset] = uint8.read(f)
-                        alpha_offset += 1
-
-    def write(self, f):
-        if self.type in (ADTAlphaTypes.LOWRES, ADTAlphaTypes.BROKEN):
-            self.header.size = 2048
-            self.header.write(f)
-
-            alpha_map_flat = []
-            for row in self.alpha_map:
-                for value in row:
-                    alpha_map_flat.append(value)
-
-            for i in range(0, 4096, 2):
-                nibble1 = alpha_map_flat[i] // (255 // 15)
-                nibble2 = alpha_map_flat[i + 1] // (255 // 15)
-                uint8.write(f, nibble1 + (nibble2 << 4))
-
-        elif self.type == ADTAlphaTypes.HIGHRES:
-            self.header.size = 4096
-            self.header.write(f)
-
-            for row in self.alpha_map:
-                for value in row:
-                    uint8.write(f, value)
-
-        elif self.type == ADTAlphaTypes.HIGHRES_COMPRESSED:
-
-            alpha_map_flat = []
-            for row in self.alpha_map:
-                for value in row:
-                    alpha_map_flat.append(value)
-
-            class Cache:
-                def __init__(self, pos=0, val=256):
-                    self.reset_pos(pos)
-                    self.reset_val(val)
-
-                def reset_pos(self, pos):
-                    self.pos = pos
-                    self.stride = 1
-
-                def reset_val(self, val):
-                    self.val = val
-                    self.count = 1
-
-                def dump(self, file, mode=None, container=None):
-                    mode = mode if mode is not None else self.count > 1
-
-                    if not (mode or container):
-                        return False
-
-                    count = (self.count if mode else self.stride - 1) & 0x7F
-                    uint8.write(file, mode * 0x80 | count)
-
-                    if mode:
-                        uint8.write(file, self.val)
-                    else:
-                        for j in range(self.pos, self.pos + count):
-                            uint8.write(file, container[j])
-
-                    return True
-
-            cache = Cache(0, alpha_map_flat[0])
-
-            for pos, val in enumerate(alpha_map_flat, 1):
-                if not (pos % 64):
-                    cache.dump(f, container=alpha_map_flat)
-                    cache.reset_pos(pos)
-                    cache.reset_val(val)
-                    continue
-
-                if cache.val != val:
-                    if cache.count > 1:
-                        cache.dump(f, True)
-                        cache.reset_pos(pos)
-                    else:
-                        cache.stride += 1
-
-                    cache.reset_val(val)
-                else:
-                    if cache.count == 1 and cache.stride > 1:
-                        cache.dump(f, False, alpha_map_flat)
-
-                    cache.count += 1
-
-            cache.dump(f, container=alpha_map_flat)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+	size = 16
+
+	def __init__(self, adt, chunk, texture_id=0, flags=0, offset_in_mcal=None, effect_id=0):
+		if offset_in_mcal is None:
+			offset_in_mcal = OFFSET(adt)
+		self.chunk = chunk
+		self.texture_id = texture_id
+		self.flags = flags
+		self.offset_in_mcal = offset_in_mcal
+		self.effect_id = effect_id
+
+	def read(self, f):
+		self.texture_id = uint32.read(f)
+		self.flags = uint32.read(f)
+
+		mcal_data_start = self.chunk._get_mcal_data_start()
+		self.offset_in_mcal.set_rel(uint32.read(f), mcal_data_start)
+		self.effect_id = uint32.read(f)
+
+	def write(self, f):
+		uint32.write(f, self.texture_id)
+		uint32.write(f, self.flags)
+		uint32.write(f, int(self.offset_in_mcal))
+		uint32.write(f, self.effect_id)
+
+
+class MCLY(MOBILE_CHUNK):
+	def __init__(self, adt, chunk):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.chunk = chunk
+		self.header = ChunkHeader('YLCM')
+		self.layers = []
+
+	def _add_layer(self, texture_id, flags, offset_in_mcal, effect_id):
+		layer = MCLYLayer(self.adt, self.chunk, texture_id, flags, offset_in_mcal, effect_id)
+		self.layers.append(layer)
+		self.adt._size_changed(MCLYLayer.size, self.address)
+
+	def _remove_layer(self, index):
+		del self.layers[index]
+		self.adt._size_changed(-MCLYLayer.size, self.address)
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+
+		for _ in range(self.header.size // MCLYLayer.size):
+			layer = MCLYLayer(self.adt, self.chunk)
+			layer.read(f)
+			self.layers.append(layer)
+
+	def write(self, f):
+		self.header.size = len(self.layers) * MCLYLayer.size
+		self.header.write(f)
+
+		for layer in self.layers:
+			layer.write(f)
+
+
+class MCRF(MOBILE_CHUNK):
+	entry_size = 4
+
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('MCRF')
+		self.doodad_refs = []
+		self.object_refs = []
+
+	def _add_doodad(self, index_in_mddf):
+		self.doodad_refs.append(index_in_mddf)
+
+	def _remove_doodad(self, index_in_mddf):
+		self.doodad_refs.remove(index_in_mddf)
+		for i in range(len(self.doodad_refs)):
+			if self.doodad_refs[i] > index_in_mddf:
+				self.doodad_refs[i] -= 1
+
+	def _add_object(self, index_in_modf):
+		self.object_refs.append(index_in_modf)
+
+	def _remove_object(self, index_in_modf):
+		self.object_refs.remove(index_in_modf)
+		for i in range(len(self.object_refs)):
+			if self.object_refs[i] > index_in_modf:
+				self.object_refs[i] -= 1
+
+	def read(self, f, n_doodad_refs, n_object_refs):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.doodad_refs = [uint32.read(f) for _ in range(n_doodad_refs)]
+		self.object_refs = [uint32.read(f) for _ in range(n_object_refs)]
+
+	def write(self, f):
+		n_doodad_refs = len(self.doodad_refs)
+		n_object_refs = len(self.object_refs)
+		self.header.size = n_doodad_refs * MCRF.entry_size + n_object_refs * MCRF.entry_size
+		self.header.write(f)
+
+		if n_doodad_refs > 0:
+			uint32.write(f, self.doodad_refs, n_doodad_refs)
+		if n_object_refs > 0:
+			uint32.write(f, self.object_refs, n_object_refs)
+
+class MCSH(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('HSCM', 512)
+		self.shadow_map = [[0 for _ in range(64)] for _ in range(64)]
+
+	def read(self, f):
+		self.set_address(f.tell())
+		self.header.read(f)
+		shadow_map_flat = []
+		for i in range(512):
+			b = uint8.read(f)
+			shadow_map_flat += uint8_to_uint1_list(b)
+		self.shadow_map = [[shadow_map_flat[i * 64 + j] for j in range(64)] for i in range(64)]
+
+	def write(self, f):
+		self.header.write(f)
+		for i in range(64):
+			for j in range(0, 64, 8):
+				b = uint1_list_to_uint8(self.shadow_map[i][j:j+8])
+				uint8.write(f, b)
+
+
+class MCALLayer:
+	def __init__(self, type=None):
+		self.type = type
+		self.alpha_map = [[0 for _ in range(64)] for _ in range(64)]
+
+	def _set_class(self):
+		class_map = {
+			ADTAlphaTypes.LOWRES : MCALLayerLowresOrBroken,
+			ADTAlphaTypes.BROKEN : MCALLayerLowresOrBroken,
+			ADTAlphaTypes.HIGHRES : MCALLayerHighres,
+			ADTAlphaTypes.HIGHRES_COMPRESSED : MCALLayerHighresCompressed,
+		}
+		self.__class__ = class_map[self.type]
+
+	def is_fully_transparent(self):
+		flattened = [item for sublist in self.alpha_map for item in sublist]
+		return not any(flattened)
+			
+	def read(self, f, alpha_type):
+		self.type = alpha_type
+		self._set_class()
+		self.read(f)
+
+	# write handled in subclasses
+
+
+class MCALLayerLowresOrBroken(MCALLayer):
+	size = 2048
+
+	def read(self, f):
+		cur_pos = 0
+		alpha_map_flat = [0] * 4096
+
+		for i in range(2048):
+			cur_byte = uint8.read(f)
+
+			nibble1 = cur_byte & 0x0F
+			nibble2 = (cur_byte & 0xF0) >> 4
+
+			first = nibble1 * 255 // 15
+			second = nibble2 * 255 // 15
+
+			alpha_map_flat[i + cur_pos + 0] = first
+			alpha_map_flat[i + cur_pos + 1] = second
+			cur_pos += 1
+
+		# Nice cropcircles
+		# self.alpha_map = [[alpha_map_flat[i * j] for i in range(64)] for j in range(64)]
+		self.alpha_map = [[alpha_map_flat[i * 64 + j] for j in range(64)] for i in range(64)]
+
+		if self.type == ADTAlphaTypes.BROKEN:
+			for row in self.alpha_map:
+				row[63] = row[62]
+
+			for i, column in enumerate(self.alpha_map[62]):
+				self.alpha_map[63][i] = column
+
+	def write(self, f):
+		alpha_map_flat = []
+		for row in self.alpha_map:
+			for value in row:
+				alpha_map_flat.append(value)
+
+		for i in range(0, 4096, 2):
+			nibble1 = alpha_map_flat[i] // (255 // 15)
+			nibble2 = alpha_map_flat[i + 1] // (255 // 15)
+			uint8.write(f, nibble1 + (nibble2 << 4))
+
+
+class MCALLayerHighres(MCALLayer):
+	size = 4096
+
+	def read(self, f):
+		self.alpha_map = [[uint8.read(f) for _ in range(64)] for _ in range(64)]
+
+	def write(self, f):
+		for row in self.alpha_map:
+			for value in row:
+				uint8.write(f, value)
+
+
+class MCALLayerHighresCompressed(MCALLayer):
+	size = 4096
+	
+	def read(self, f):
+		alpha_map_flat = [0] * 4096
+		alpha_offset = 0
+
+		while alpha_offset < 4096:
+			cur_byte = uint8.read(f)
+			mode = bool(cur_byte >> 7)
+			count = cur_byte & 0b1111111
+
+			if mode:  # fill
+				alpha = uint8.read(f)
+				for i in range(count):
+					alpha_map_flat[alpha_offset] = alpha
+					alpha_offset += 1
+			else:  # copy
+				for i in range(count):
+					alpha_map_flat[alpha_offset] = uint8.read(f)
+					alpha_offset += 1
+
+	def write(self, f):
+		alpha_map_flat = []
+		for row in self.alpha_map:
+			for value in row:
+				alpha_map_flat.append(value)
+
+		class Cache:
+			def __init__(self, pos=0, val=256):
+				self.reset_pos(pos)
+				self.reset_val(val)
+
+			def reset_pos(self, pos):
+				self.pos = pos
+				self.stride = 1
+
+			def reset_val(self, val):
+				self.val = val
+				self.count = 1
+
+			def dump(self, file, mode=None, container=None):
+				mode = mode if mode is not None else self.count > 1
+
+				if not (mode or container):
+					return False
+
+				count = (self.count if mode else self.stride - 1) & 0x7F
+				uint8.write(file, mode * 0x80 | count)
+
+				if mode:
+					uint8.write(file, self.val)
+				else:
+					for j in range(self.pos, self.pos + count):
+						uint8.write(file, container[j])
+
+				return True
+
+		cache = Cache(0, alpha_map_flat[0])
+
+		for pos, val in enumerate(alpha_map_flat, 1):
+			if not (pos % 64):
+				cache.dump(f, container=alpha_map_flat)
+				cache.reset_pos(pos)
+				cache.reset_val(val)
+				continue
+
+			if cache.val != val:
+				if cache.count > 1:
+					cache.dump(f, True)
+					cache.reset_pos(pos)
+				else:
+					cache.stride += 1
+
+				cache.reset_val(val)
+			else:
+				if cache.count == 1 and cache.stride > 1:
+					cache.dump(f, False, alpha_map_flat)
+
+				cache.count += 1
+
+		cache.dump(f, container=alpha_map_flat)
+
+
+class MCAL(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('LACM')
+		self.layers = []
+
+	def _add_layer(self, type):
+		layer = MCALLayer(type)
+		layer._set_class()
+		self.layers.append(layer)
+		ofs = 0
+		for i in range(1, len(self.layers)):
+			ofs += self.layers[i].size
+
+		address_of_change = self.address + ChunkHeader.size + ofs
+		self.adt._size_changed(layer.size, address_of_change)
+		return ofs
+
+	def _remove_layer(self, index, address):
+		self.adt._size_changed(-self.layers[index].size, address)
+		del self.layers[index]
+
+	def read(self, f, n_layers, alpha_is_broken, alpha_is_compressed):
+		self.set_address(f.tell())
+		self.header.read(f)
+
+		if n_layers < 2:
+			return
+		
+		# Inferred from MCAL size, rather than WDT MPHD flags
+		# Assume all layers have the same size
+		# TODO: read from WDT MPHD flags
+		alpha_is_highres = False
+		alpha_size = self.header.size / (n_layers - 1)
+		if alpha_size == 2048:
+			alpha_is_highres = False
+		elif alpha_size == 4096:
+			alpha_is_highres = True
+		else:
+			raise Exception("MCAL alpha size must be 2048 or 4096. Found: {}".format(alpha_size))
+
+		for i in range(n_layers - 1):
+			alpha_type = None
+
+			if alpha_is_highres:
+				if alpha_is_compressed[i]:
+					alpha_type = ADTAlphaTypes.HIGHRES_COMPRESSED
+				else:
+					alpha_type = ADTAlphaTypes.HIGHRES
+			else:
+				if alpha_is_broken:
+					alpha_type = ADTAlphaTypes.BROKEN
+				else:
+					alpha_type = ADTAlphaTypes.LOWRES
+
+			layer = MCALLayer()
+			layer.read(f, alpha_type)
+			self.layers.append(layer)
+
+	def write(self, f):
+		size = 0
+		for layer in self.layers:
+			# l_type = layer.type
+			# size += l_type <= 1 and 2048 or 4096
+			size += layer.size
+		self.header.size = size
+		self.header.write(f)
+		for layer in self.layers:
+			layer.write(f)
+
+
+class MCSESoundEmitter:
+	size = 28
+
+	def __init__(self, entry_id=0, position=None, size=None):
+		if position is None:
+			position = C3Vector()
+		if size is None:
+			size = C3Vector()
+		self.entry_id = entry_id
+		self.position = position
+		self.size = size
+
+	def read(self, f):
+		self.entry_id = uint32.read(f)
+		self.position.read(f)
+		self.size.read(f)
+
+	def write(self, f):
+		uint32.write(f, self.entry_id)
+		self.position.write(f)
+		self.size.write(f)
+
+
+class MCSE(MOBILE_CHUNK):
+	def __init__(self, adt):
+		MOBILE_CHUNK.__init__(self, adt)
+		self.header = ChunkHeader('ESCM')
+		self.entries = []
+
+	def _add_entry(self, entry_id, position, size):
+		entry = MCSESoundEmitter(entry_id, position, size)
+		self.entries.append(entry)
+		self.adt._size_changed(MCSESoundEmitter.size, self.address)
+
+	def _remove_entry(self, index):
+		del self.entries[index]
+		self.adt._size_changed(-MCSESoundEmitter.size, self.address)
+
+	def read(self, f, n_sound_emitters):
+		self.set_address(f.tell())
+		self.header.read(f)
+		self.entries = [MCSESoundEmitter() for _ in range(n_sound_emitters)]
+
+	def write(self, f):
+		self.header.size = len(self.entries) * MCSESoundEmitter.size
+		self.header.write(f)
+		for entry in self.entries:
+			entry.write(f)
+
+
+# TODO
+# class MCLQ:
+	# def __init__(self):
+	# def read(self, f):
+	# def write(self, f):
+
+
+
+def uint8_to_smaller(uint8, bit_depth=1, LSB_first=True):
+	l = []
+	mask = 0b1
+
+	for _ in range(bit_depth - 1):
+		mask = (mask << 1) | 0b1
+
+	for i in range(0, 8, bit_depth):
+		n = None
+		if LSB_first:
+			n = (uint8 >> i) & mask
+		else:
+			n = (uint8 >> (8-i-bit_depth)) & mask
+		l.append(n)
+
+	return l
+
+def uint8_to_uint1_list(uint8, LSB_first=True):
+	return uint8_to_smaller(uint8, 1)
+def uint8_to_uint2_list(uint8, LSB_first=True):
+	return uint8_to_smaller(uint8, 2)
+
+
+def smaller_list_to_uint8(l, bit_depth=1, LSB_first=True):
+	if (len(l) * bit_depth) != 8:
+		raise ValueError('List length * bit depth should equal 8.')
+
+	uint8 = 0
+	for i in range(len(l)):
+		if LSB_first:
+			uint8 |= l[i] << (bit_depth * i)
+		else:
+			uint8 |= l[-1 - i] << (bit_depth * i)
+
+	return uint8
+
+def uint1_list_to_uint8(l, LSB_first=True):
+	return smaller_list_to_uint8(l, 1, LSB_first)
+def uint2_list_to_uint8(l, LSB_first=True):
+	return smaller_list_to_uint8(l, 2, LSB_first)

--- a/file_formats/adt_chunks.py
+++ b/file_formats/adt_chunks.py
@@ -58,8 +58,11 @@ class MOBILE_CHUNK(ADT_REF):
 
 
 class MVER:
+	magic = 'REVM'
+	data_size = 4
+
 	def __init__(self):
-		self.header = ChunkHeader('REVM', 4)
+		self.header = ChunkHeader(MVER.magic, MVER.data_size)
 		self.version = 18
 
 	def read(self, f):
@@ -76,8 +79,11 @@ class MVER:
 
 
 class MHDR:
+	magic = 'RDHM'
+	data_size = 54
+
 	def __init__(self, adt):
-		self.header = ChunkHeader('RDHM', 54)
+		self.header = ChunkHeader(MHDR.magic, MHDR.data_size)
 		self.start_data = 0
 		self.flags = 0
 		self.ofs_mcin = OFFSET(adt)
@@ -133,6 +139,8 @@ class MHDR:
 
 
 class MCIN_entry:
+	size = 16
+
 	def __init__(self, adt):
 		self.offset = OFFSET(adt)
 		self.size = 0
@@ -158,9 +166,12 @@ class MCIN_entry:
 
 
 class MCIN(MOBILE_CHUNK):
+	magic = 'NICM'
+	data_size = 16
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('NICM', 16)
+		self.header = ChunkHeader(MCIN.magic, MCIN.data_size)
 		self.entries = [MCIN_entry(adt) for _ in range(256)]
 
 	def read(self, f):
@@ -172,7 +183,7 @@ class MCIN(MOBILE_CHUNK):
 		return self
 
 	def write(self, f):
-		self.header.size = len(self.entries) * 16
+		self.header.size = len(self.entries) * MCIN_entry.size
 		self.header.write(f)
 
 		for entry in self.entries:
@@ -205,11 +216,12 @@ class MMDX(MOBILE_CHUNK, StringBlockChunk):
 
 
 class MMID(MOBILE_CHUNK):
+	magic = 'DIMM'
 	entry_size = 4
 
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('DIMM')
+		self.header = ChunkHeader(MMID.magic)
 		self.offsets = []
 
 	def _add(self, ofs):
@@ -253,11 +265,12 @@ class MWMO(MOBILE_CHUNK, StringBlockChunk):
 
 
 class MWID(MOBILE_CHUNK):
+	magic = 'DIWM'
 	entry_size = 4
 
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('DIWM')
+		self.header = ChunkHeader(MWID.magic)
 		self.offsets = []
 
 	def _add(self, ofs):
@@ -326,9 +339,11 @@ class ADTDoodadDefinition:
 
 
 class MDDF(MOBILE_CHUNK):
+	magic = 'FDDM'
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('FDDM')
+		self.header = ChunkHeader(MDDF.magic)
 		self.doodad_instances = []
 
 	def _add(self, name_id, unique_id, position, rotation, scale, flags):
@@ -405,9 +420,11 @@ class ADTWMODefinition:
 
 
 class MODF(MOBILE_CHUNK):
+	magic = 'FDOM'
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('FDOM')
+		self.header = ChunkHeader(MODF.magic)
 		self.wmo_instances = []
 
 	def _add(self, name_id, unique_id, position, rotation, 
@@ -442,9 +459,11 @@ class MODF(MOBILE_CHUNK):
 
 
 class MFBO(MOBILE_CHUNK):
+	magic = 'OBFM'
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('OBFM')
+		self.header = ChunkHeader(MFBO.magic)
 		self.maximum = [[0] * 3] * 3
 		self.minimum = [[0] * 3] * 3
 
@@ -508,9 +527,11 @@ class MFBO(MOBILE_CHUNK):
 
 #     def write(self, f):
 class MH2O(MOBILE_CHUNK):
+	magic = 'O2HM'
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('O2HM')
+		self.header = ChunkHeader(MH2O.magic)
 		# TODO
 		self.data = []
 
@@ -527,11 +548,12 @@ class MH2O(MOBILE_CHUNK):
 
 
 class MTXF(MOBILE_CHUNK):
+	magic = 'FXTM'
 	entry_size = 4
 
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('FXTM')
+		self.header = ChunkHeader(MTXF.magic)
 		self.flags = []
 
 	def _add(self, flags):
@@ -554,9 +576,11 @@ class MTXF(MOBILE_CHUNK):
 
 
 class MCNK(MOBILE_CHUNK):
+	magic = 'KNCM'
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('KNCM')
+		self.header = ChunkHeader(MCNK.magic)
 		self.flags = 0
 		self.index_x = 0
 		self.index_y = 0
@@ -727,7 +751,8 @@ class MCNK(MOBILE_CHUNK):
 			is_comp = layer.flags & ADTChunkLayerFlags.alpha_map_compressed
 			alpha_is_compressed.append(is_comp)
 		f.seek(self.address + int(self.ofs_mcal))
-		self.mcal.read(f, self.n_layers, alpha_is_broken, alpha_is_compressed)
+		n_alpha_layers = self.n_layers - 1
+		self.mcal.read(f, n_alpha_layers, alpha_is_broken, alpha_is_compressed)
 
 		if (self.flags & ADTChunkFlags.HAS_MCSH):
 			f.seek(self.address + int(self.ofs_mcsh))
@@ -875,9 +900,12 @@ class MCNK(MOBILE_CHUNK):
 
 
 class MCVT(MOBILE_CHUNK):
+	magic = 'TVCM'
+	data_size = 580
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('TVCM', 580)
+		self.header = ChunkHeader(MCVT.magic, MCVT.data_size)
 		self.height = [0.0] * 145
 
 	def read(self, f):
@@ -907,9 +935,12 @@ class MCLV(MOBILE_CHUNK):
 
 
 class MCCV(MOBILE_CHUNK):
+	magic = 'VCCM'
+	data_size = 580
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('VCCM', 580)
+		self.header = ChunkHeader(MCCV.magic, MCCV.data_size)
 		self.colors = [(255, 255, 255, 255)] * 145
 
 	def read(self, f):
@@ -923,9 +954,12 @@ class MCCV(MOBILE_CHUNK):
 
 
 class MCNR(MOBILE_CHUNK):
+	magic = 'RNCM'
+	data_size = 435 if CLIENT_VERSION <= WoWVersions.WOTLK else 448
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('RNCM', 435 if CLIENT_VERSION <= WoWVersions.WOTLK else 448)
+		self.header = ChunkHeader(MCNR.magic, MCNR.data_size)
 		self.normals = [(0, 0, 0)] * 145
 		self.unknown = [0] * 13
 
@@ -969,10 +1003,12 @@ class MCLYLayer:
 
 
 class MCLY(MOBILE_CHUNK):
+	magic = 'YLCM'
+
 	def __init__(self, adt, chunk):
 		MOBILE_CHUNK.__init__(self, adt)
 		self.chunk = chunk
-		self.header = ChunkHeader('YLCM')
+		self.header = ChunkHeader(MCLY.magic)
 		self.layers = []
 
 	def _add_layer(self, texture_id, flags, offset_in_mcal, effect_id):
@@ -1002,11 +1038,12 @@ class MCLY(MOBILE_CHUNK):
 
 
 class MCRF(MOBILE_CHUNK):
+	magic = 'MCRF'
 	entry_size = 4
 
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('MCRF')
+		self.header = ChunkHeader(MCRF.magic)
 		self.doodad_refs = []
 		self.object_refs = []
 
@@ -1046,9 +1083,11 @@ class MCRF(MOBILE_CHUNK):
 			uint32.write(f, self.object_refs, n_object_refs)
 
 class MCSH(MOBILE_CHUNK):
+	magic = 'HSCM'
+	data_size = 512
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('HSCM', 512)
+		self.header = ChunkHeader(MCSH.magic, MCSH.data_size)
 		self.shadow_map = [[0 for _ in range(64)] for _ in range(64)]
 
 	def read(self, f):
@@ -1095,13 +1134,13 @@ class MCALLayer:
 
 
 class MCALLayerLowresOrBroken(MCALLayer):
-	size = 2048
+	size = ADTAlphaSize.LOWRES
 
 	def read(self, f):
 		cur_pos = 0
-		alpha_map_flat = [0] * 4096
+		alpha_map_flat = [0] * ADTAlphaSize.HIGHRES
 
-		for i in range(2048):
+		for i in range(ADTAlphaSize.LOWRES):
 			cur_byte = uint8.read(f)
 
 			nibble1 = cur_byte & 0x0F
@@ -1131,14 +1170,14 @@ class MCALLayerLowresOrBroken(MCALLayer):
 			for value in row:
 				alpha_map_flat.append(value)
 
-		for i in range(0, 4096, 2):
+		for i in range(0, ADTAlphaSize.HIGHRES, 2):
 			nibble1 = alpha_map_flat[i] // (255 // 15)
 			nibble2 = alpha_map_flat[i + 1] // (255 // 15)
 			uint8.write(f, nibble1 + (nibble2 << 4))
 
 
 class MCALLayerHighres(MCALLayer):
-	size = 4096
+	size = ADTAlphaSize.HIGHRES
 
 	def read(self, f):
 		self.alpha_map = [[uint8.read(f) for _ in range(64)] for _ in range(64)]
@@ -1150,13 +1189,13 @@ class MCALLayerHighres(MCALLayer):
 
 
 class MCALLayerHighresCompressed(MCALLayer):
-	size = 4096
+	size = ADTAlphaSize.HIGHRES
 	
 	def read(self, f):
-		alpha_map_flat = [0] * 4096
+		alpha_map_flat = [0] * ADTAlphaSize.HIGHRES
 		alpha_offset = 0
 
-		while alpha_offset < 4096:
+		while alpha_offset < ADTAlphaSize.HIGHRES:
 			cur_byte = uint8.read(f)
 			mode = bool(cur_byte >> 7)
 			count = cur_byte & 0b1111111
@@ -1234,9 +1273,11 @@ class MCALLayerHighresCompressed(MCALLayer):
 
 
 class MCAL(MOBILE_CHUNK):
+	magic = 'LACM'
+
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('LACM')
+		self.header = ChunkHeader(MCAL.magic)
 		self.layers = []
 
 	def _add_layer(self, type):
@@ -1255,48 +1296,39 @@ class MCAL(MOBILE_CHUNK):
 		self.adt._size_changed(-self.layers[index].size, address)
 		del self.layers[index]
 
-	def read(self, f, n_layers, alpha_is_broken, alpha_is_compressed):
+	def _get_alpha_type(self, alpha_is_highres, alpha_is_compressed, alpha_is_broken):
+		alpha_type = None
+
+		if alpha_is_highres:
+			if alpha_is_compressed:
+				alpha_type = ADTAlphaTypes.HIGHRES_COMPRESSED
+			else:
+				alpha_type = ADTAlphaTypes.HIGHRES
+		else:
+			if alpha_is_broken:
+				alpha_type = ADTAlphaTypes.BROKEN
+			else:
+				alpha_type = ADTAlphaTypes.LOWRES
+
+		return alpha_type
+
+	def read(self, f, n_alpha_layers, alpha_is_broken, alpha_is_compressed):
 		self.set_address(f.tell())
 		self.header.read(f)
 
-		if n_layers < 2:
+		if n_alpha_layers < 1:
 			return
-		
-		# Inferred from MCAL size, rather than WDT MPHD flags
-		# Assume all layers have the same size
-		# TODO: read from WDT MPHD flags
-		alpha_is_highres = False
-		alpha_size = self.header.size / (n_layers - 1)
-		if alpha_size == 2048:
-			alpha_is_highres = False
-		elif alpha_size == 4096:
-			alpha_is_highres = True
-		else:
-			raise Exception("MCAL alpha size must be 2048 or 4096. Found: {}".format(alpha_size))
 
-		for i in range(n_layers - 1):
-			alpha_type = None
-
-			if alpha_is_highres:
-				if alpha_is_compressed[i]:
-					alpha_type = ADTAlphaTypes.HIGHRES_COMPRESSED
-				else:
-					alpha_type = ADTAlphaTypes.HIGHRES
-			else:
-				if alpha_is_broken:
-					alpha_type = ADTAlphaTypes.BROKEN
-				else:
-					alpha_type = ADTAlphaTypes.LOWRES
-
+		alpha_is_highres = self.adt.highres
+		for i in range(n_alpha_layers):
 			layer = MCALLayer()
+			alpha_type = self._get_alpha_type(alpha_is_highres, alpha_is_compressed[i], alpha_is_broken)
 			layer.read(f, alpha_type)
 			self.layers.append(layer)
 
 	def write(self, f):
 		size = 0
 		for layer in self.layers:
-			# l_type = layer.type
-			# size += l_type <= 1 and 2048 or 4096
 			size += layer.size
 		self.header.size = size
 		self.header.write(f)
@@ -1328,9 +1360,11 @@ class MCSESoundEmitter:
 
 
 class MCSE(MOBILE_CHUNK):
+	magic = 'ESCM'
+	
 	def __init__(self, adt):
 		MOBILE_CHUNK.__init__(self, adt)
-		self.header = ChunkHeader('ESCM')
+		self.header = ChunkHeader(MCSE.magic)
 		self.entries = []
 
 	def _add_entry(self, entry_id, position, size):
@@ -1362,7 +1396,7 @@ class MCSE(MOBILE_CHUNK):
 
 
 
-def uint8_to_smaller(uint8, bit_depth=1, LSB_first=True):
+def uint8_to_uintX_list(uint8, bit_depth=1, LSB_first=True):
 	l = []
 	mask = 0b1
 
@@ -1380,9 +1414,9 @@ def uint8_to_smaller(uint8, bit_depth=1, LSB_first=True):
 	return l
 
 def uint8_to_uint1_list(uint8, LSB_first=True):
-	return uint8_to_smaller(uint8, 1)
+	return uint8_to_uintX_list(uint8, 1)
 def uint8_to_uint2_list(uint8, LSB_first=True):
-	return uint8_to_smaller(uint8, 2)
+	return uint8_to_uintX_list(uint8, 2)
 
 
 def smaller_list_to_uint8(l, bit_depth=1, LSB_first=True):


### PR DESCRIPTION
I mostly completed support for ADT 3.3.5
I'm not a great programmer so take this with a heap of salt. Hopefully it can be at least a little useful.

It's fairly straight forward except for how offset values are handled:
There's a whole bunch of offset values throughout ADTs and they need to be updated if there's a change in size somewhere. For this purpose I added an OFFSET class. All OFFSET instances need to get updated via the ADTFile._size_changed function whenever a change occurs.
In hindsight this might not be the best solution. I kind of like the idea of being able to create a valid ADT from scratch, which isn't currently possible because the offsets need to be valid from the start (when they're read from the file). But for now it works.

I formatted ADT flags as binary because I think it makes more sense, but it's easy to change to hex if you prefer.

I added some functions to safely handle more complex operations. Most of them are in the ADTFile class, and a couple in the MCNK class:

```
ADTFile
	add_texture_filename(filename, mtxf_flags=0)
	replace_texture_filename(index, new_filename)
	remove_texture_filename(index)

	add_m2_filename(filename)
	replace_m2_filename(index, new_filename)
	remove_m2_filename(index)

	add_wmo_filename(filename)
	replace_wmo_filename(index, new_filename)
	remove_wmo_filename(index)

	add_m2_instance(which_chunks, name_id, unique_id, position, rotation, scale, flags)
	remove_m2_instance(index)

	add_wmo_instance(which_chunks, name_id, unique_id, position, rotation, extents, flags, doodad_set, name_set, scale)
	remove_wmo_instance(index)


MCNK
	add_sound_emitter(entry_id, position, size)
	remove_sound_emitter(index)

	add_texture_layer(texture_id, flags, effect_id)
	remove_texture_layer(index)
```