### PR TITLE
Fix adding texture alpha layer.

### DIFF
--- a/file_formats/adt_chunks.py
+++ b/file_formats/adt_chunks.py
@@ -1286,7 +1286,7 @@ class MCAL(MOBILE_CHUNK):
 		for i in range(1, len(self.layers)):
 			ofs += self.layers[i].size
 
-		address_of_change = self.address + ChunkHeader.size + ofs
+		address_of_change = self.address + ChunkHeader.size + ofs - 1	# Dirty, but should be safe
 		self.adt._size_changed(layer.size, address_of_change)
 		return ofs
 


### PR DESCRIPTION
Fixed the bug I found while double-checking ADT manipulation (when adding an MCAL layer, MCSE offset wasn't being updated because its address was identical to the offset of the MCAL layer).

It shouldn't cause any errors because no offset is ever 1 less than an MCAL layer offset (so no offset is erroneously updated), but it still feels kind of dirty. Another downside of handling offsets this way, I guess.