### PR TITLE
Build native extensions on modern Linux (cmake 4, gcc 16 / C23 default)

### DIFF
--- a/archives/mpq/native/setup.py
+++ b/archives/mpq/native/setup.py
@@ -35,6 +35,7 @@ def main(debug: bool):
     os.chdir(build_dir)
 
     cmake_defines = ['-DCMAKE_BUILD_TYPE=Debug' if debug else '-DCMAKE_BUILD_TYPE=Release'
+        , '-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
         , '-DBUILD_SHARED_LIBS=OFF']
 
     if sys.platform != 'win32':

--- a/blp/BLP2PNG/setup.py
+++ b/blp/BLP2PNG/setup.py
@@ -46,6 +46,15 @@ def main(debug: bool):
         else:
             extra_compile_args = ['-std=c++17', '-O3']
             extra_link_args = []
+        # The bundled zlib/libpng C sources predate C23; gcc 16 defaults to C23
+        # and turns K&R definitions and implicit declarations (lseek/read/...)
+        # into hard errors. Relax those back to warnings and pull in unistd.
+        extra_compile_args += [
+            '-Wno-implicit-function-declaration',
+            '-Wno-implicit-int',
+            '-fcommon',
+            '-DZ_HAVE_UNISTD_H',
+        ]
 
     extensions = [Extension(
         "BLP2PNG",

--- a/blp/PNG2BLP/setup.py
+++ b/blp/PNG2BLP/setup.py
@@ -45,6 +45,13 @@ def main(debug: bool):
         else:
             extra_compile_args = ['-std=c++17', '-O3']
             extra_link_args = []
+        # Bundled zlib C sources predate C23; relax gcc 16's defaults (see BLP2PNG).
+        extra_compile_args += [
+            '-Wno-implicit-function-declaration',
+            '-Wno-implicit-int',
+            '-fcommon',
+            '-DZ_HAVE_UNISTD_H',
+        ]
 
     setup(
         name='BLP To PNG Converter',


### PR DESCRIPTION
Trying to build pywowlib on a current Linux setup (Arch, cmake 4.x, gcc 16) hit a couple of small breaks. These are toolchain-only fixes, nothing changes on existing/older setups.

- `archives/mpq/native/setup.py`: pass `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to StormLib's cmake. cmake 4 removed compatibility with the pre-3.5 `cmake_minimum_required()` StormLib still declares, so configure aborts with "Compatibility with CMake < 3.5 has been removed" otherwise.

- `blp/BLP2PNG/setup.py` and `blp/PNG2BLP/setup.py`: the bundled zlib/libpng C predates C23 (K&R parameter lists, implicit `lseek`/`read` without unistd.h). gcc 16 defaults to C23 and makes both hard errors, so the BLP extensions don't compile. Relaxed those back to warnings for these extensions (`-Wno-implicit-function-declaration`, `-Wno-implicit-int`, `-fcommon`) and defined `Z_HAVE_UNISTD_H` so zlib pulls the header itself. Only on the non-Windows branch.

Verified by building pywowlib as part of WoW Blender Studio against a Python 3.10.8 that matches Blender 3.4 - CASC, MPQ and both BLP extensions compile and import fine after this.

There's a matching one-liner needed in pyCASCLib (same cmake policy thing) which I've put up separately since it's a different repo.

Happy to adjust anything.
